### PR TITLE
SANC-38: add an icon button type that only has an icon with no text

### DIFF
--- a/src/app/_components/Button.module.scss
+++ b/src/app/_components/Button.module.scss
@@ -1,54 +1,54 @@
 @import "@/styles/variables";
 
 .primaryButton {
-	background-color: $color-primary;
-	color: $color-primary-text;
+  background-color: $color-primary;
+  color: $color-primary-text;
 
-	&:hover:not(:disabled) {
-		background-color: $color-primary-hover;
-		color: $color-primary-hover-text;
-	}
+  &:hover:not(:disabled) {
+    background-color: $color-primary-hover;
+    color: $color-primary-hover-text;
+  }
 }
 
 .secondaryButton {
-	background-color: $color-secondary;
-	color: $color-secondary-text;
-	border: 1px solid $color-light-grey;
+  background-color: $color-secondary;
+  color: $color-secondary-text;
+  border: 1px solid $color-light-grey;
 
-	&:hover:not(:disabled) {
-		background-color: $color-secondary-hover;
-		color: $color-secondary-text;
-	}
+  &:hover:not(:disabled) {
+    background-color: $color-secondary-hover;
+    color: $color-secondary-text;
+  }
 }
 
 .disabledButton {
-	background-color: $color-disabled;
-	color: $color-disabled-text;
-	border: none;
-	cursor: not-allowed;
+  background-color: $color-disabled;
+  color: $color-disabled-text;
+  border: none;
+  cursor: not-allowed;
 
-	&:hover {
-		background-color: $color-disabled;
-		color: $color-disabled-text;
-	}
+  &:hover {
+    background-color: $color-disabled;
+    color: $color-disabled-text;
+  }
 }
 
 .iconButton {
-	background-color: $color-secondary;
-	color: $color-secondary-text;
-	border: 1px solid $color-light-grey;
+  background-color: $color-secondary;
+  color: $color-secondary-text;
+  border: 1px solid $color-light-grey;
 
-	/* Ensure a comfortable touch target */
-	min-width: 44px;
-	min-height: 44px;
-	padding: 0;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	border-radius: 8px;
+  /* Ensure a comfortable touch target */
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
 
-	&:hover:not(:disabled) {
-		background-color: $color-secondary-hover;
-		color: $color-secondary-hover;
-	}
+  &:hover:not(:disabled) {
+    background-color: $color-secondary-hover;
+    color: $color-secondary-hover;
+  }
 }

--- a/src/app/_components/Button.module.scss
+++ b/src/app/_components/Button.module.scss
@@ -34,21 +34,11 @@
 }
 
 .iconButton {
-  background-color: $color-secondary;
-  color: $color-secondary-text;
-  border: 1px solid $color-light-grey;
-
-  /* Ensure a comfortable touch target */
-  min-width: 44px;
-  min-height: 44px;
-  padding: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
+  background-color: $color-primary;
+  color: $color-primary-text;
 
   &:hover:not(:disabled) {
-    background-color: $color-secondary-hover;
-    color: $color-secondary-hover;
+    background-color: $color-primary-hover;
+    color: $color-primary-hover-text;
   }
 }

--- a/src/app/_components/Button.module.scss
+++ b/src/app/_components/Button.module.scss
@@ -1,34 +1,54 @@
 @import "@/styles/variables";
 
 .primaryButton {
-  background-color: $color-primary;
-  color: $color-primary-text;
+	background-color: $color-primary;
+	color: $color-primary-text;
 
-  &:hover:not(:disabled) {
-    background-color: $color-primary-hover;
-    color: $color-primary-hover-text;
-  }
+	&:hover:not(:disabled) {
+		background-color: $color-primary-hover;
+		color: $color-primary-hover-text;
+	}
 }
 
 .secondaryButton {
-  background-color: $color-secondary;
-  color: $color-secondary-text;
-  border: 1px solid $color-light-grey;
+	background-color: $color-secondary;
+	color: $color-secondary-text;
+	border: 1px solid $color-light-grey;
 
-  &:hover:not(:disabled) {
-    background-color: $color-secondary-hover;
-    color: $color-secondary-text;
-  }
+	&:hover:not(:disabled) {
+		background-color: $color-secondary-hover;
+		color: $color-secondary-text;
+	}
 }
 
 .disabledButton {
-  background-color: $color-disabled;
-  color: $color-disabled-text;
-  border: none;
-  cursor: not-allowed;
+	background-color: $color-disabled;
+	color: $color-disabled-text;
+	border: none;
+	cursor: not-allowed;
 
-  &:hover {
-    background-color: $color-disabled;
-    color: $color-disabled-text;
-  }
+	&:hover {
+		background-color: $color-disabled;
+		color: $color-disabled-text;
+	}
+}
+
+.iconButton {
+	background-color: $color-secondary;
+	color: $color-secondary-text;
+	border: 1px solid $color-light-grey;
+
+	/* Ensure a comfortable touch target */
+	min-width: 44px;
+	min-height: 44px;
+	padding: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 8px;
+
+	&:hover:not(:disabled) {
+		background-color: $color-secondary-hover;
+		color: $color-secondary-hover;
+	}
 }

--- a/src/app/_components/Button.module.scss
+++ b/src/app/_components/Button.module.scss
@@ -21,6 +21,16 @@
   }
 }
 
+.iconButton {
+  background-color: $color-primary;
+  color: $color-primary-text;
+
+  &:hover:not(:disabled) {
+    background-color: $color-primary-hover;
+    color: $color-primary-hover-text;
+  }
+}
+
 .disabledButton {
   background-color: $color-disabled;
   color: $color-disabled-text;
@@ -33,12 +43,13 @@
   }
 }
 
-.iconButton {
-  background-color: $color-primary;
-  color: $color-primary-text;
+.transparentButton {
+  background-color: transparent;
+  color: $color-primary;
+  border: none;
 
   &:hover:not(:disabled) {
-    background-color: $color-primary-hover;
-    color: $color-primary-hover-text;
+    background-color: rgba($color-primary-hover, 0.1);
+    color: $color-primary-hover;
   }
 }

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -4,10 +4,10 @@ import { Button as MantineButton } from "@mantine/core";
 import type { ReactNode } from "react";
 import styles from "./Button.module.scss";
 
-export type ButtonVariant = "primary" | "secondary";
+export type ButtonVariant = "primary" | "secondary" | "icon";
 
 export interface ButtonProps {
-  text: string;
+  text?: string;
   variant?: ButtonVariant;
   color?: string;
   width?: string | number;
@@ -16,6 +16,7 @@ export interface ButtonProps {
   icon?: ReactNode;
   onClick?: () => void;
   disabled?: boolean;
+  ariaLabel?: string;
 }
 
 export default function Button({
@@ -28,8 +29,18 @@ export default function Button({
   icon,
   onClick,
   disabled = false,
+  ariaLabel,
 }: ButtonProps) {
   const isPrimary = variant === "primary";
+  const isIconOnly = variant === "icon" || (!text && !!icon);
+
+  // Accessibility enforcement (development only)
+  if (isIconOnly && !ariaLabel && process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Button: icon-only button rendered without `ariaLabel` — provide `ariaLabel` for screen reader accessibility.",
+    );
+  }
 
   return (
     <MantineButton
@@ -38,6 +49,7 @@ export default function Button({
       disabled={disabled}
       variant={isPrimary ? "filled" : "outline"}
       leftSection={icon}
+      aria-label={ariaLabel}
       classNames={{
         root: disabled
           ? styles.disabledButton

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -4,10 +4,10 @@ import { Button as MantineButton } from "@mantine/core";
 import type { ReactNode } from "react";
 import styles from "./Button.module.scss";
 
-export type ButtonVariant = "primary" | "secondary" | "icon";
+export type ButtonVariant = "primary" | "secondary";
 
 export interface ButtonProps {
-  text?: string;
+  text: string;
   variant?: ButtonVariant;
   color?: string;
   width?: string | number;
@@ -16,7 +16,6 @@ export interface ButtonProps {
   icon?: ReactNode;
   onClick?: () => void;
   disabled?: boolean;
-  ariaLabel?: string;
 }
 
 export default function Button({
@@ -29,18 +28,8 @@ export default function Button({
   icon,
   onClick,
   disabled = false,
-  ariaLabel,
 }: ButtonProps) {
   const isPrimary = variant === "primary";
-  const isIconOnly = variant === "icon" || (!text && !!icon);
-
-  // Accessibility enforcement (development only)
-  if (isIconOnly && !ariaLabel && process.env.NODE_ENV !== "production") {
-    // eslint-disable-next-line no-console
-    console.warn(
-      "Button: icon-only button rendered without `ariaLabel` — provide `ariaLabel` for screen reader accessibility.",
-    );
-  }
 
   return (
     <MantineButton
@@ -48,16 +37,13 @@ export default function Button({
       onClick={onClick}
       disabled={disabled}
       variant={isPrimary ? "filled" : "outline"}
-      {...(isIconOnly ? {} : { leftSection: icon })}
-      aria-label={ariaLabel}
+      leftSection={icon}
       classNames={{
         root: disabled
           ? styles.disabledButton
-          : isIconOnly
-            ? styles.iconButton
-            : isPrimary
-              ? styles.primaryButton
-              : styles.secondaryButton,
+          : isPrimary
+            ? styles.primaryButton
+            : styles.secondaryButton,
       }}
       styles={{
         root: {
@@ -69,7 +55,7 @@ export default function Button({
         },
       }}
     >
-      {isIconOnly ? icon : text}
+      {text}
     </MantineButton>
   );
 }

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -15,12 +15,24 @@ export interface ButtonProps {
   fontSize?: string | number;
   icon?: ReactNode;
   onClick?: () => void;
+  transparent?: boolean;
   disabled?: boolean;
 }
 
-function getButtonStyles(variant: ButtonVariant, disabled: boolean) {
-  if (disabled) return styles.disabledButton;
-  return variant === "primary" ? styles.primaryButton : styles.secondaryButton;
+function getButtonStyles(variant: ButtonVariant, disabled: boolean, transparent: boolean) {
+  const classes = [];
+
+  if (disabled) {
+    classes.push(styles.disabledButton);
+  } else {
+    classes.push(variant === "primary" ? styles.primaryButton : styles.secondaryButton);
+  }
+
+  if (transparent) {
+    classes.push(styles.transparentButton);
+  }
+
+  return classes.join(" ");
 }
 
 export default function Button({
@@ -32,19 +44,18 @@ export default function Button({
   fontSize,
   icon,
   onClick,
+  transparent = false,
   disabled = false,
 }: ButtonProps) {
-  const isPrimary = variant === "primary";
-
   return (
     <MantineButton
       type="button"
       onClick={onClick}
       disabled={disabled}
-      variant={isPrimary ? "filled" : "outline"}
+      variant={transparent ? "transparent" : "filled"}
       leftSection={icon}
       classNames={{
-        root: getButtonStyles(variant, disabled),
+        root: getButtonStyles(variant, disabled, transparent),
       }}
       styles={{
         root: {

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -18,6 +18,11 @@ export interface ButtonProps {
   disabled?: boolean;
 }
 
+function getButtonStyles(variant: ButtonVariant, disabled: boolean) {
+  if (disabled) return styles.disabledButton;
+  return variant === "primary" ? styles.primaryButton : styles.secondaryButton;
+}
+
 export default function Button({
   text,
   variant = "primary",
@@ -39,11 +44,7 @@ export default function Button({
       variant={isPrimary ? "filled" : "outline"}
       leftSection={icon}
       classNames={{
-        root: disabled
-          ? styles.disabledButton
-          : isPrimary
-            ? styles.primaryButton
-            : styles.secondaryButton,
+        root: getButtonStyles(variant, disabled),
       }}
       styles={{
         root: {

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -48,14 +48,16 @@ export default function Button({
       onClick={onClick}
       disabled={disabled}
       variant={isPrimary ? "filled" : "outline"}
-      leftSection={icon}
+      {...(isIconOnly ? {} : { leftSection: icon })}
       aria-label={ariaLabel}
       classNames={{
         root: disabled
           ? styles.disabledButton
-          : isPrimary
-            ? styles.primaryButton
-            : styles.secondaryButton,
+          : isIconOnly
+            ? styles.iconButton
+            : isPrimary
+              ? styles.primaryButton
+              : styles.secondaryButton,
       }}
       styles={{
         root: {
@@ -67,7 +69,7 @@ export default function Button({
         },
       }}
     >
-      {text}
+      {isIconOnly ? icon : text}
     </MantineButton>
   );
 }

--- a/src/app/_components/IconButton.tsx
+++ b/src/app/_components/IconButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { ActionIcon } from "@mantine/core";
+import type { ReactNode } from "react";
+import styles from "./Button.module.scss";
+
+export interface IconButtonProps {
+  icon: ReactNode;
+  onClick?: () => void;
+  ariaLabel: string; // required for accessibility
+  color?: string;
+  width?: string | number;
+  height?: string | number;
+  size?: "sm" | "md" | "lg" | number;
+  variant?: "filled" | "outline" | "transparent";
+  disabled?: boolean;
+}
+
+export default function IconButton({
+  icon,
+  onClick,
+  ariaLabel,
+  color,
+  width,
+  height,
+  size = "md",
+  variant = "filled",
+  disabled = false,
+}: IconButtonProps) {
+  return (
+    <ActionIcon
+      onClick={onClick}
+      aria-label={ariaLabel}
+      color={color ?? "var(--color-primary)"}
+      variant={variant}
+      size={size}
+      disabled={disabled}
+      className={variant === "filled" ? styles.iconButton : undefined}
+      style={{
+        width: width,
+        height: height,
+      }}
+    >
+      {icon}
+    </ActionIcon>
+  );
+}

--- a/src/app/_components/IconButton.tsx
+++ b/src/app/_components/IconButton.tsx
@@ -16,6 +16,17 @@ export interface IconButtonProps {
   disabled?: boolean;
 }
 
+function getIconButtonStyles(disabled: boolean, transparent: boolean) {
+  const classes = [styles.iconButton];
+  if (disabled) {
+    classes.push(styles.disabledButton);
+  }
+  if (transparent) {
+    classes.push(styles.transparentButton);
+  }
+  return classes.join(" ");
+}
+
 export default function IconButton({
   icon,
   onClick,
@@ -27,17 +38,6 @@ export default function IconButton({
   transparent = false,
   disabled = false,
 }: IconButtonProps) {
-  const getIconButtonClass = () => {
-    const classes = [styles.iconButton];
-    if (disabled) {
-      classes.push(styles.disabledButton);
-    }
-    if (transparent) {
-      classes.push(styles.transparentButton);
-    }
-    return classes.join(" ");
-  };
-
   return (
     <ActionIcon
       onClick={onClick}
@@ -46,7 +46,7 @@ export default function IconButton({
       variant={transparent ? "transparent" : "filled"}
       size={size}
       disabled={disabled}
-      className={getIconButtonClass()}
+      className={getIconButtonStyles(disabled, transparent)}
       style={{
         width: width,
         height: height,

--- a/src/app/_components/IconButton.tsx
+++ b/src/app/_components/IconButton.tsx
@@ -12,7 +12,7 @@ export interface IconButtonProps {
   width?: string | number;
   height?: string | number;
   size?: "sm" | "md" | "lg" | number;
-  variant?: "filled" | "outline" | "transparent";
+  transparent?: boolean;
   disabled?: boolean;
 }
 
@@ -24,18 +24,29 @@ export default function IconButton({
   width,
   height,
   size = "md",
-  variant = "filled",
+  transparent = false,
   disabled = false,
 }: IconButtonProps) {
+  const getIconButtonClass = () => {
+    const classes = [styles.iconButton];
+    if (disabled) {
+      classes.push(styles.disabledButton);
+    }
+    if (transparent) {
+      classes.push(styles.transparentButton);
+    }
+    return classes.join(" ");
+  };
+
   return (
     <ActionIcon
       onClick={onClick}
       aria-label={ariaLabel}
-      color={color ?? "var(--color-primary)"}
-      variant={variant}
+      color={color}
+      variant={transparent ? "transparent" : "filled"}
       size={size}
       disabled={disabled}
-      className={variant === "filled" ? styles.iconButton : undefined}
+      className={getIconButtonClass()}
       style={{
         width: width,
         height: height,

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -6,6 +6,7 @@ import Location from "@/assets/icons/location";
 import Plus from "@/assets/icons/plus";
 import { Divider, Group, Stack, Title } from "@mantine/core";
 import Button from "../_components/Button";
+import IconButton from "../_components/IconButton";
 
 export default function StylesPage() {
   return (
@@ -55,12 +56,13 @@ export default function StylesPage() {
             Icon Buttons
           </Title>
           <Group>
-            <Button icon={<Plus />} variant="icon" ariaLabel="plus" /> icon
-            <Button icon={<Chevron />} variant="icon" ariaLabel="chevron" disabled />
+            <IconButton icon={<Plus />} ariaLabel="plus" size="sm" /> sm
+            <IconButton icon={<Plus />} ariaLabel="plus" size="lg" /> lg
+            <IconButton icon={<Chevron />} ariaLabel="chevron" disabled />
             disabled
-            <Button icon={<Face />} variant="icon" ariaLabel="clock" width="200px" />
+            <IconButton icon={<Face />} ariaLabel="clock" width="200px" />
             Custom Width
-            <Button icon={<Location />} variant="icon" ariaLabel="location" height="60px" />
+            <IconButton icon={<Location />} ariaLabel="location" height="50px" />
             Custom Height
           </Group>
         </Stack>

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -60,10 +60,14 @@ export default function StylesPage() {
             <IconButton icon={<Plus />} ariaLabel="plus" size="lg" /> lg
             <IconButton icon={<Chevron />} ariaLabel="chevron" disabled />
             disabled
-            <IconButton icon={<Face />} ariaLabel="clock" width="200px" />
+            <IconButton icon={<Face />} ariaLabel="face" width="200px" />
             Custom Width
             <IconButton icon={<Location />} ariaLabel="location" height="50px" />
             Custom Height
+          </Group>
+          <Group>
+            <IconButton icon={<Plus />} ariaLabel="plus" variant="outline" /> outline
+            <IconButton icon={<Plus />} ariaLabel="plus" variant="transparent" /> transparent
           </Group>
         </Stack>
       </Stack>

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -64,10 +64,7 @@ export default function StylesPage() {
             Custom Width
             <IconButton icon={<Location />} ariaLabel="location" height="50px" />
             Custom Height
-          </Group>
-          <Group>
-            <IconButton icon={<Plus />} ariaLabel="plus" variant="outline" /> outline
-            <IconButton icon={<Plus />} ariaLabel="plus" variant="transparent" /> transparent
+            <IconButton icon={<Plus />} ariaLabel="plus" transparent /> transparent
           </Group>
         </Stack>
       </Stack>

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import Bell from "@/assets/icons/bell";
-import Calendar from "@/assets/icons/calendar";
 import Chevron from "@/assets/icons/chevron";
-import Clock from "@/assets/icons/clock";
-import Cross from "@/assets/icons/cross";
+import Face from "@/assets/icons/face";
+import Location from "@/assets/icons/location";
 import Plus from "@/assets/icons/plus";
 import { Divider, Group, Stack, Title } from "@mantine/core";
 import Button from "../_components/Button";
@@ -57,12 +55,13 @@ export default function StylesPage() {
             Icon Buttons
           </Title>
           <Group>
-            <Button icon={<Plus />} variant="icon" /> icon
-            <Button icon={<Bell />} variant="icon" /> small
-            <Button icon={<Calendar />} variant="icon" /> large
-            <Button icon={<Chevron />} variant="icon" disabled /> disabled
-            <Button icon={<Clock />} variant="icon" /> custom width
-            <Button icon={<Cross />} variant="icon" /> custom height
+            <Button icon={<Plus />} variant="icon" ariaLabel="plus" /> icon
+            <Button icon={<Chevron />} variant="icon" ariaLabel="chevron" disabled />
+            disabled
+            <Button icon={<Face />} variant="icon" ariaLabel="clock" width="200px" />
+            Custom Width
+            <Button icon={<Location />} variant="icon" ariaLabel="location" height="60px" />
+            Custom Height
           </Group>
         </Stack>
       </Stack>

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import Bell from "@/assets/icons/bell";
+import Calendar from "@/assets/icons/calendar";
+import Chevron from "@/assets/icons/chevron";
+import Clock from "@/assets/icons/clock";
+import Cross from "@/assets/icons/cross";
 import Plus from "@/assets/icons/plus";
 import { Divider, Group, Stack, Title } from "@mantine/core";
 import Button from "../_components/Button";
@@ -44,6 +49,20 @@ export default function StylesPage() {
           </Title>
           <Group>
             <Button text="Disabled Button" disabled />
+          </Group>
+        </Stack>
+
+        <Stack gap="sm">
+          <Title order={3} size="h4">
+            Icon Buttons
+          </Title>
+          <Group>
+            <Button icon={<Plus />} variant="icon" /> icon
+            <Button icon={<Bell />} variant="icon" /> small
+            <Button icon={<Calendar />} variant="icon" /> large
+            <Button icon={<Chevron />} variant="icon" disabled /> disabled
+            <Button icon={<Clock />} variant="icon" /> custom width
+            <Button icon={<Cross />} variant="icon" /> custom height
           </Group>
         </Stack>
       </Stack>


### PR DESCRIPTION
Here's what I did:

- add "icon" button variant
- ariaLabel is for accessibility/screen readers
- Development-time console warning remains for any icon-only button missing an accessible (ariaLabel) name.
- update style guide with icon button examples

<img width="987" height="142" alt="image" src="https://github.com/user-attachments/assets/2c3b00e8-0242-49df-a5d8-6d3352ae0a5a" />