### PR TITLE
SANC-21: skeleton for top nav

### DIFF
--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Bell from "@/assets/icons/bell";
+import Home from "@/assets/icons/home";
+import User from "@/assets/icons/user";
+import { Group, Text } from "@mantine/core";
+import Button from "./Button";
+
+type NavbarView = "admin" | "agency" | "driver";
+
+interface NavbarProps {
+  view: NavbarView;
+  agencyName?: string; //only used in Agency View
+}
+
+export default function Navbar({ view, agencyName }: NavbarProps) {
+  return (
+    <Group justify="space-between" px="lg" py="md">
+      <Group>
+        <Home />
+        <Text>
+          {view === "admin"
+            ? "Admin Home"
+            : view === "agency"
+              ? `${agencyName ?? "[Agency name]"} Home`
+              : ""}
+        </Text>
+      </Group>
+
+      {view === "admin" && (
+        <Group gap={20}>
+          <Button text="Rider Logs" variant="secondary" />
+          <Button text="Vehicle Log" variant="secondary" />
+          <Button text="Schedule" variant="secondary" />
+          <User />
+        </Group>
+      )}
+
+      {view === "agency" && (
+        <Group gap={30}>
+          <Bell />
+          <User />
+        </Group>
+      )}
+
+      {view === "driver" && (
+        <Group>
+          <User />
+        </Group>
+      )}
+    </Group>
+  );
+}

--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -15,7 +15,7 @@ interface NavbarProps {
 
 export default function Navbar({ view, agencyName }: NavbarProps) {
   return (
-    <Group justify="space-between" className="border-bottom">
+    <Group justify="space-between" className="border-bottom" style={{ padding: "1rem 2rem" }}>
       <Group>
         <Home />
         <Text>

--- a/src/app/_components/navbar.tsx
+++ b/src/app/_components/navbar.tsx
@@ -15,7 +15,7 @@ interface NavbarProps {
 
 export default function Navbar({ view, agencyName }: NavbarProps) {
   return (
-    <Group justify="space-between" px="lg" py="md">
+    <Group justify="space-between" className="border-bottom">
       <Group>
         <Home />
         <Text>

--- a/src/app/agency/home/agency-page.module.scss
+++ b/src/app/agency/home/agency-page.module.scss
@@ -1,6 +1,7 @@
 .schedulePage {
   min-height: 100vh;
-  padding: 1rem;
+  padding: 1rem 2rem;
+  padding-top: 0;
 
   .header {
     display: flex;

--- a/src/app/agency/home/page.tsx
+++ b/src/app/agency/home/page.tsx
@@ -3,6 +3,7 @@ import Face from "@/assets/icons/face";
 import Home from "@/assets/icons/home";
 
 import { AgencyInteractiveArea } from "@/app/_components/agencycomponents/agency-interactive-area";
+import Navbar from "@/app/_components/navbar";
 import { HydrateClient, api } from "@/trpc/server";
 import { ViewMode } from "@/types/types";
 import styles from "./agency-page.module.scss";
@@ -13,17 +14,8 @@ export default async function AgencyHome() {
 
   return (
     <HydrateClient>
+      <Navbar view="agency" />
       <main className={styles.schedulePage}>
-        <header className={styles.header}>
-          <div className={styles.headerLeft}>
-            <Home />
-            <span>agency name home</span>
-          </div>
-          <div className={styles.headerRight}>
-            <Bell />
-            <Face />
-          </div>
-        </header>
         <h1 className={styles.title}>This Week's Navigation Schedule</h1>
 
         <AgencyInteractiveArea initialViewMode={ViewMode.CALENDAR} />

--- a/src/assets/icons/user.tsx
+++ b/src/assets/icons/user.tsx
@@ -1,0 +1,51 @@
+import { memo } from "react";
+import type { SVGProps } from "react";
+
+const SvgComponent = ({ width = "32px", height = "32px", ...props }: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="none"
+    viewBox="0 0 32 32"
+    aria-label="User"
+    {...props}
+  >
+    <title>User</title>
+    <path
+      stroke="#434343"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M24 25.333v-1.777c0-.943-.421-1.848-1.172-2.515C22.078 20.375 21.061 20 20 20h-8c-1.06 0-2.078.375-2.828 1.041C8.422 21.708 8 22.613 8 23.556v1.777M16 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"
+    />
+    <path
+      stroke="#434343"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M16.133 29.223c7.364 0 13.333-5.97 13.333-13.334S23.496 2.556 16.133 2.556c-7.364 0-13.334 5.97-13.334 13.333 0 7.364 5.97 13.334 13.334 13.334Z"
+    />
+    <g>
+      <path
+        stroke="#000"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeOpacity={0.2}
+        strokeWidth={2}
+        d="M24 25.333v-1.777c0-.943-.421-1.848-1.172-2.515C22.078 20.375 21.061 20 20 20h-8c-1.06 0-2.078.375-2.828 1.041C8.422 21.708 8 22.613 8 23.556v1.777M16 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"
+      />
+      <path
+        stroke="#000"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeOpacity={0.2}
+        strokeWidth={2}
+        d="M16.133 29.223c7.364 0 13.333-5.97 13.333-13.334S23.496 2.556 16.133 2.556c-7.364 0-13.334 5.97-13.334 13.333 0 7.364 5.97 13.334 13.334 13.334Z"
+      />
+    </g>
+  </svg>
+);
+
+const User = memo(SvgComponent);
+export default User;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -92,3 +92,7 @@ p,
 .border { 
   border: 1px solid $color-border; 
 }
+
+.border-bottom { 
+  border-bottom: 1px solid $color-border; 
+}


### PR DESCRIPTION
created a common navbar for 3 different views (admin, agency and driver). can pass an agency name to display at the top on the agency page.

also added a user icon

<img width="1896" height="78" alt="Screenshot 2025-11-06 165359" src="https://github.com/user-attachments/assets/585555d1-69a7-4d73-96cf-30e4b330fe47" />
<img width="1897" height="79" alt="Screenshot 2025-11-06 165446" src="https://github.com/user-attachments/assets/27f4ea0a-b2c9-4b84-93f4-ea6223adff56" />
<img width="528" height="80" alt="Screenshot 2025-11-06 165509" src="https://github.com/user-attachments/assets/23fb9075-03a4-48a2-8af2-4439c74d9ed1" />