### PR TITLE
Create DB schema for trip feedback/surveys

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     "./src/server/db/schema.ts", // data schema
     "./src/server/db/auth-schema.ts", // auth schema
     "./src/server/db/booking-schema.ts", // booking schema
-    "./src/server/db/trip-schema.ts", // trip schema
+    "./src/server/db/post-trip-schema.ts", // post-trip schema
   ],
   dialect: "postgresql",
   dbCredentials: {

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "./src/server/db/schema.ts", // data schema
     "./src/server/db/auth-schema.ts", // auth schema
     "./src/server/db/booking-schema.ts", // booking schema
+    "./src/server/db/trip-schema.ts", // trip schema
   ],
   dialect: "postgresql",
   dbCredentials: {

--- a/drizzle/0000_sparkling_raider.sql
+++ b/drizzle/0000_sparkling_raider.sql
@@ -1,0 +1,134 @@
+CREATE TABLE "form" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"title" text NOT NULL,
+	"description" text,
+	"submitted_by_id" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "account" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp,
+	"refresh_token_expires_at" timestamp,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "invitation" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"email" text NOT NULL,
+	"role" text,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"inviter_id" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "member" (
+	"id" text PRIMARY KEY NOT NULL,
+	"organization_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text DEFAULT 'member' NOT NULL,
+	"created_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organization" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"logo" text,
+	"created_at" timestamp NOT NULL,
+	"metadata" text,
+	CONSTRAINT "organization_slug_unique" UNIQUE("slug")
+);
+--> statement-breakpoint
+CREATE TABLE "session" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	"active_organization_id" text,
+	CONSTRAINT "session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "user" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"role" text DEFAULT 'driver' NOT NULL,
+	CONSTRAINT "user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "verification" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "bookings" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"pickup_address" text NOT NULL,
+	"destination_address" text NOT NULL,
+	"purpose" text,
+	"passenger_info" text NOT NULL,
+	"status" text DEFAULT 'incomplete' NOT NULL,
+	"agency_id" text NOT NULL,
+	"start_time" timestamp with time zone NOT NULL,
+	"end_time" timestamp with time zone NOT NULL,
+	"driver_id" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now(),
+	"created_by" text,
+	"updated_by" text
+);
+--> statement-breakpoint
+CREATE TABLE "post_trip_surveys" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"booking_id" integer NOT NULL,
+	"driver_id" text NOT NULL,
+	"trip_completion_status" text DEFAULT 'completed' NOT NULL,
+	"start_reading" integer NOT NULL,
+	"end_reading" integer,
+	"time_of_departure" timestamp,
+	"time_of_arrival" timestamp,
+	"destination_address" text,
+	"original_location_changed" boolean,
+	"passenger_fit_rating" integer,
+	"comments" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "passenger_fit_rating_check" CHECK ("post_trip_surveys"."passenger_fit_rating" >= 1 AND "post_trip_surveys"."passenger_fit_rating" <= 5)
+);
+--> statement-breakpoint
+ALTER TABLE "form" ADD CONSTRAINT "form_submitted_by_id_user_id_fk" FOREIGN KEY ("submitted_by_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "account" ADD CONSTRAINT "account_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "invitation" ADD CONSTRAINT "invitation_inviter_id_user_id_fk" FOREIGN KEY ("inviter_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member" ADD CONSTRAINT "member_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member" ADD CONSTRAINT "member_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_agency_id_user_id_fk" FOREIGN KEY ("agency_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_driver_id_user_id_fk" FOREIGN KEY ("driver_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bookings" ADD CONSTRAINT "bookings_updated_by_user_id_fk" FOREIGN KEY ("updated_by") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_trip_surveys" ADD CONSTRAINT "post_trip_surveys_booking_id_bookings_id_fk" FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "post_trip_surveys" ADD CONSTRAINT "post_trip_surveys_driver_id_user_id_fk" FOREIGN KEY ("driver_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -3,8 +3,8 @@ import postgres from "postgres";
 import { env } from "@/env";
 import * as authSchema from "@/server/db/auth-schema";
 import * as bookingSchema from "@/server/db/booking-schema";
+import * as postTripSchema from "@/server/db/post-trip-schema";
 import * as schema from "@/server/db/schema";
-import * as tripSchema from "@/server/db/trip-schema";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
@@ -20,5 +20,5 @@ const conn = globalForDb.conn ?? postgres(env.DATABASE_URL);
 if (env.NODE_ENV !== "production") globalForDb.conn = conn;
 
 export const db = drizzle(conn, {
-  schema: { ...schema, ...authSchema, ...bookingSchema, ...tripSchema },
+  schema: { ...schema, ...authSchema, ...bookingSchema, ...postTripSchema },
 });

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -2,7 +2,11 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { env } from "@/env";
 import * as authSchema from "@/server/db/auth-schema";
+import * as bookingSchema from "@/server/db/booking-schema";
 import * as schema from "@/server/db/schema";
+import * as tripSchema from "@/server/db/trip-schema";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
 
 /**
  * Cache the database connection in development. This avoids creating a new connection on every HMR
@@ -15,4 +19,6 @@ const globalForDb = globalThis as unknown as {
 const conn = globalForDb.conn ?? postgres(env.DATABASE_URL);
 if (env.NODE_ENV !== "production") globalForDb.conn = conn;
 
-export const db = drizzle(conn, { schema: { ...schema, ...authSchema } });
+export const db = drizzle(conn, {
+  schema: { ...schema, ...authSchema, ...bookingSchema, ...tripSchema },
+});

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -5,8 +5,6 @@ import * as authSchema from "@/server/db/auth-schema";
 import * as bookingSchema from "@/server/db/booking-schema";
 import * as postTripSchema from "@/server/db/post-trip-schema";
 import * as schema from "@/server/db/schema";
-import { drizzle } from "drizzle-orm/postgres-js";
-import postgres from "postgres";
 
 /**
  * Cache the database connection in development. This avoids creating a new connection on every HMR

--- a/src/server/db/post-trip-schema.ts
+++ b/src/server/db/post-trip-schema.ts
@@ -46,9 +46,11 @@ export const odometerReadings = pgTable("odometer_readings", {
     .references(() => user.id, { onDelete: "cascade" }),
   startReading: integer("start_reading").notNull(),
   endReading: integer("end_reading"),
-  totalDistance: integer("total_distance"),
-  imageUrl: text("image_url"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at")
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date()),
 });
 
 // Relations

--- a/src/server/db/post-trip-schema.ts
+++ b/src/server/db/post-trip-schema.ts
@@ -13,7 +13,7 @@ export const postTripSurveys = pgTable(
       .references(() => bookings.id, { onDelete: "cascade" }),
     driverId: text("driver_id")
       .notNull()
-      .references(() => user.id, { onDelete: "cascade" }),
+      .references(() => user.id, { onDelete: "restrict" }),
 
     // Trip completion
     tripCompletionStatus: text("trip_completion_status", {

--- a/src/server/db/post-trip-schema.ts
+++ b/src/server/db/post-trip-schema.ts
@@ -1,5 +1,5 @@
 import { relations } from "drizzle-orm";
-import { integer, jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, integer, jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema";
 import { bookings } from "./booking-schema";
 
@@ -14,8 +14,6 @@ export const postTripSurveys = pgTable("post_trip_surveys", {
   })
     .notNull()
     .default("completed"),
-  // Survey questions
-  surveyQuestions: jsonb("survey_questions"), // e.g., { question1: "...", question2: "...", etc. }
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
@@ -28,10 +26,9 @@ export const driverFeedback = pgTable("driver_feedback", {
   driverId: text("driver_id")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
-  rating: integer("rating"),
+  originalLocationChanged: boolean("original_location_changed"),
+  passengerFitRating: integer("passenger_fit_rating"),
   comments: text("comments"),
-  // Answers to survey
-  surveyAnswers: jsonb("survey_answers"), // e.g., { answer1: "...", answer2: "...", etc. }
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
@@ -46,11 +43,10 @@ export const odometerReadings = pgTable("odometer_readings", {
     .references(() => user.id, { onDelete: "cascade" }),
   startReading: integer("start_reading").notNull(),
   endReading: integer("end_reading"),
+  timeOfDeparture: timestamp("time_of_departure"),
+  timeOfArrival: timestamp("time_of_arrival"),
+  destinationAddress: text("destination_address"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
-    .defaultNow()
-    .notNull()
-    .$onUpdate(() => new Date()),
 });
 
 // Relations

--- a/src/server/db/post-trip-schema.ts
+++ b/src/server/db/post-trip-schema.ts
@@ -1,39 +1,48 @@
-import { relations } from "drizzle-orm";
-import { boolean, integer, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+import { boolean, check, integer, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema";
 import { bookings } from "./booking-schema";
 
 // Post-trip survey
-export const postTripSurveys = pgTable("post_trip_surveys", {
-  id: serial("id").primaryKey(),
-  bookingId: integer("booking_id")
-    .notNull()
-    .references(() => bookings.id, { onDelete: "cascade" }),
-  driverId: text("driver_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
+export const postTripSurveys = pgTable(
+  "post_trip_surveys",
+  {
+    id: serial("id").primaryKey(),
+    bookingId: integer("booking_id")
+      .notNull()
+      .references(() => bookings.id, { onDelete: "cascade" }),
+    driverId: text("driver_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
 
-  // Trip completion
-  tripCompletionStatus: text("trip_completion_status", {
-    enum: ["completed", "partially_completed", "cancelled", "no_show"],
-  })
-    .notNull()
-    .default("completed"),
+    // Trip completion
+    tripCompletionStatus: text("trip_completion_status", {
+      enum: ["completed", "partially_completed", "cancelled", "no_show"],
+    })
+      .notNull()
+      .default("completed"),
 
-  // Odometer readings
-  startReading: integer("start_reading").notNull(),
-  endReading: integer("end_reading"),
-  timeOfDeparture: timestamp("time_of_departure"),
-  timeOfArrival: timestamp("time_of_arrival"),
-  destinationAddress: text("destination_address"),
+    // Odometer readings
+    startReading: integer("start_reading").notNull(),
+    endReading: integer("end_reading"),
+    timeOfDeparture: timestamp("time_of_departure"),
+    timeOfArrival: timestamp("time_of_arrival"),
+    destinationAddress: text("destination_address"),
 
-  // Driver feedback
-  originalLocationChanged: boolean("original_location_changed"),
-  passengerFitRating: integer("passenger_fit_rating"),
-  comments: text("comments"),
+    // Driver feedback
+    originalLocationChanged: boolean("original_location_changed"),
+    passengerFitRating: integer("passenger_fit_rating"),
+    comments: text("comments"),
 
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => ({
+    passengerFitRatingCheck: check(
+      "passenger_fit_rating_check",
+      sql`${table.passengerFitRating} >= 1 AND ${table.passengerFitRating} <= 5`,
+    ),
+  }),
+);
 
 // Relations
 export const postTripSurveysRelations = relations(postTripSurveys, ({ one }) => ({

--- a/src/server/db/post-trip-schema.ts
+++ b/src/server/db/post-trip-schema.ts
@@ -1,51 +1,37 @@
 import { relations } from "drizzle-orm";
-import { boolean, integer, jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, integer, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
 import { user } from "./auth-schema";
 import { bookings } from "./booking-schema";
 
-// Post-trip surveys
+// Post-trip survey
 export const postTripSurveys = pgTable("post_trip_surveys", {
   id: serial("id").primaryKey(),
   bookingId: integer("booking_id")
     .notNull()
     .references(() => bookings.id, { onDelete: "cascade" }),
+  driverId: text("driver_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+
+  // Trip completion
   tripCompletionStatus: text("trip_completion_status", {
     enum: ["completed", "partially_completed", "cancelled", "no_show"],
   })
     .notNull()
     .default("completed"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
 
-// Driver feedback
-export const driverFeedback = pgTable("driver_feedback", {
-  id: serial("id").primaryKey(),
-  surveyId: integer("survey_id")
-    .notNull()
-    .references(() => postTripSurveys.id, { onDelete: "cascade" }),
-  driverId: text("driver_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
-  originalLocationChanged: boolean("original_location_changed"),
-  passengerFitRating: integer("passenger_fit_rating"),
-  comments: text("comments"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-});
-
-// Odometer readings
-export const odometerReadings = pgTable("odometer_readings", {
-  id: serial("id").primaryKey(),
-  bookingId: integer("booking_id")
-    .notNull()
-    .references(() => bookings.id, { onDelete: "cascade" }),
-  driverId: text("driver_id")
-    .notNull()
-    .references(() => user.id, { onDelete: "cascade" }),
+  // Odometer readings
   startReading: integer("start_reading").notNull(),
   endReading: integer("end_reading"),
   timeOfDeparture: timestamp("time_of_departure"),
   timeOfArrival: timestamp("time_of_arrival"),
   destinationAddress: text("destination_address"),
+
+  // Driver feedback
+  originalLocationChanged: boolean("original_location_changed"),
+  passengerFitRating: integer("passenger_fit_rating"),
+  comments: text("comments"),
+
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });
 
@@ -55,27 +41,8 @@ export const postTripSurveysRelations = relations(postTripSurveys, ({ one }) => 
     fields: [postTripSurveys.bookingId],
     references: [bookings.id],
   }),
-}));
-
-export const driverFeedbackRelations = relations(driverFeedback, ({ one }) => ({
-  survey: one(postTripSurveys, {
-    fields: [driverFeedback.surveyId],
-    references: [postTripSurveys.id],
-  }),
   driver: one(user, {
-    fields: [driverFeedback.driverId],
-    references: [user.id],
-  }),
-}));
-
-// Relations for odometer readings
-export const odometerReadingsRelations = relations(odometerReadings, ({ one }) => ({
-  booking: one(bookings, {
-    fields: [odometerReadings.bookingId],
-    references: [bookings.id],
-  }),
-  driver: one(user, {
-    fields: [odometerReadings.driverId],
+    fields: [postTripSurveys.driverId],
     references: [user.id],
   }),
 }));

--- a/src/server/db/trip-schema.ts
+++ b/src/server/db/trip-schema.ts
@@ -1,0 +1,83 @@
+import { relations } from "drizzle-orm";
+import { integer, jsonb, pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./auth-schema";
+import { bookings } from "./booking-schema";
+
+// Post-trip surveys
+export const postTripSurveys = pgTable("post_trip_surveys", {
+  id: serial("id").primaryKey(),
+  bookingId: integer("booking_id")
+    .notNull()
+    .references(() => bookings.id, { onDelete: "cascade" }),
+  tripCompletionStatus: text("trip_completion_status", {
+    enum: ["completed", "partially_completed", "cancelled", "no_show"],
+  })
+    .notNull()
+    .default("completed"),
+  // Survey questions
+  surveyQuestions: jsonb("survey_questions"), // e.g., { question1: "...", question2: "...", etc. }
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+// Driver feedback
+export const driverFeedback = pgTable("driver_feedback", {
+  id: serial("id").primaryKey(),
+  surveyId: integer("survey_id")
+    .notNull()
+    .references(() => postTripSurveys.id, { onDelete: "cascade" }),
+  driverId: text("driver_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  rating: integer("rating"),
+  comments: text("comments"),
+  // Answers to survey
+  surveyAnswers: jsonb("survey_answers"), // e.g., { answer1: "...", answer2: "...", etc. }
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+// Odometer readings
+export const odometerReadings = pgTable("odometer_readings", {
+  id: serial("id").primaryKey(),
+  bookingId: integer("booking_id")
+    .notNull()
+    .references(() => bookings.id, { onDelete: "cascade" }),
+  driverId: text("driver_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  startReading: integer("start_reading").notNull(),
+  endReading: integer("end_reading"),
+  totalDistance: integer("total_distance"),
+  imageUrl: text("image_url"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+// Relations
+export const postTripSurveysRelations = relations(postTripSurveys, ({ one }) => ({
+  booking: one(bookings, {
+    fields: [postTripSurveys.bookingId],
+    references: [bookings.id],
+  }),
+}));
+
+export const driverFeedbackRelations = relations(driverFeedback, ({ one }) => ({
+  survey: one(postTripSurveys, {
+    fields: [driverFeedback.surveyId],
+    references: [postTripSurveys.id],
+  }),
+  driver: one(user, {
+    fields: [driverFeedback.driverId],
+    references: [user.id],
+  }),
+}));
+
+// Relations for odometer readings
+export const odometerReadingsRelations = relations(odometerReadings, ({ one }) => ({
+  booking: one(bookings, {
+    fields: [odometerReadings.bookingId],
+    references: [bookings.id],
+  }),
+  driver: one(user, {
+    fields: [odometerReadings.driverId],
+    references: [user.id],
+  }),
+}));


### PR DESCRIPTION
DB schema for trip feedback/surveys. I'm thinking we can store survey questions and answers in a json object in postTripSurvey and driverFeedback respectively. I also haven't created a migration for this.

Jira: https://codethechangeyyc.atlassian.net/jira/software/projects/SANC/boards/68?selectedIssue=SANC-25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post‑trip surveys to capture completion status, start/end odometer, departure/arrival times, destination address, passenger fit rating (1–5) and free‑form comments.
  * Survey responses link to individual trips and drivers for per‑trip feedback and reporting.

* **Chores**
  * Backend schema and migration added to store and relate post‑trip survey data with bookings and drivers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->