### PR TITLE
SANC-41: Add scheduled date time field to booking schema

### DIFF
--- a/src/server/api/routers/trip.ts
+++ b/src/server/api/routers/trip.ts
@@ -12,6 +12,7 @@ export const tripRouter = createTRPCRouter({
         dropoffLocation: z.string(),
         purpose: z.string(),
         passengerInfo: z.string(),
+        // Requires ISO 8601 String
         scheduledTime: z.string().datetime(),
       }),
     )

--- a/src/server/api/routers/trip.ts
+++ b/src/server/api/routers/trip.ts
@@ -13,7 +13,8 @@ export const tripRouter = createTRPCRouter({
         purpose: z.string(),
         passengerInfo: z.string(),
         // Requires ISO 8601 String
-        scheduledTime: z.string().datetime(),
+        startTime: z.string().datetime(),
+        endTime: z.string().datetime(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -25,7 +26,8 @@ export const tripRouter = createTRPCRouter({
         agencyId: ctx.session.user.id,
         purpose: input.purpose,
         createdBy: ctx.session.user.id,
-        scheduledTime: input.scheduledTime,
+        startTime: input.startTime,
+        endTime: input.endTime,
       });
     }),
 });

--- a/src/server/api/routers/trip.ts
+++ b/src/server/api/routers/trip.ts
@@ -12,6 +12,7 @@ export const tripRouter = createTRPCRouter({
         dropoffLocation: z.string(),
         purpose: z.string(),
         passengerInfo: z.string(),
+        scheduledTime: z.string().datetime(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -23,6 +24,7 @@ export const tripRouter = createTRPCRouter({
         agencyId: ctx.session.user.id,
         purpose: input.purpose,
         createdBy: ctx.session.user.id,
+        scheduledTime: input.scheduledTime,
       });
     }),
 });

--- a/src/server/db/booking-schema.ts
+++ b/src/server/db/booking-schema.ts
@@ -16,7 +16,11 @@ export const bookings = pgTable("bookings", {
   agencyId: text("agency_id")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
-  scheduledTime: timestamp("scheduled_time", {
+  startTime: timestamp("start_time", {
+    mode: "string",
+    withTimezone: true,
+  }).notNull(),
+  endTime: timestamp("end_time", {
     mode: "string",
     withTimezone: true,
   }).notNull(),

--- a/src/server/db/booking-schema.ts
+++ b/src/server/db/booking-schema.ts
@@ -8,7 +8,7 @@ export const bookings = pgTable("bookings", {
   pickupLocation: text("pickup_location").notNull(),
   dropoffLocation: text("dropoff_location").notNull(),
   purpose: text("purpose"),
-  passengerInfo: text("passengerInfo").notNull(),
+  passengerInfo: text("passenger_info").notNull(),
   status: text("status", { enum: ["incomplete", "completed", "in-progress"] })
     .notNull()
     .default("incomplete"),
@@ -16,7 +16,10 @@ export const bookings = pgTable("bookings", {
   agencyId: text("agency_id")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
-
+  scheduledTime: timestamp("scheduled_time", {
+    mode: "string",
+    withTimezone: true,
+  }).notNull(),
   driverId: text("driver_id").references(() => user.id, {
     onDelete: "set null",
   }),


### PR DESCRIPTION
Requires a ISO 8601 datetime string including Timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip bookings now support start and end time specifications. Users can define precise scheduling windows with full timezone awareness when creating trips. Time information is automatically recorded with each booking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->