### PR TITLE
Sanc 22 create the only datepicker component

### DIFF
--- a/src/app/_components/agencycomponents/agency-form.tsx
+++ b/src/app/_components/agencycomponents/agency-form.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Box, Divider, Stack, Textarea, TextInput } from "@mantine/core";
-import { DateTimePicker } from "@mantine/dates";
 import type { UseFormReturnType } from "@mantine/form";
+import DatePicker from "@/app/_components/common/datepicker/DatePicker";
 import classes from "./agency-form.module.scss";
 
 interface AgencyBookingForm {
@@ -79,27 +79,13 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
           Logistics
         </Box>
 
-        <div className={classes.formRow}>
-          <DateTimePicker
-            withAsterisk
-            label="Date and time of transport"
-            placeholder="Select date and time"
-            valueFormat="DD MMM YYYY hh:mm A"
-            key={form.key("startTime")}
-            {...form.getInputProps("startTime")}
-          />
-        </div>
-
-        <div className={classes.formRow}>
-          <DateTimePicker
-            withAsterisk
-            label="Date and time of arrival"
-            placeholder="Select date and time"
-            valueFormat="DD MMM YYYY hh:mm A"
-            key={form.key("endTime")}
-            {...form.getInputProps("endTime")}
-          />
-        </div>
+        <DatePicker
+          required
+          label="Date and time of transport"
+          placeholder="Select date and time"
+          key={form.key("transportDateTime")}
+          {...form.getInputProps("transportDateTime")}
+        />
 
         <div className={classes.formRow}>
           <TextInput

--- a/src/app/_components/common/datepicker/DatePicker.module.scss
+++ b/src/app/_components/common/datepicker/DatePicker.module.scss
@@ -1,0 +1,29 @@
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 0 1rem;
+  align-items: start;
+
+  // Override Mantine's default input styles
+  :global(.mantine-InputWrapper-root) {
+    display: contents;
+  }
+
+  :global(.mantine-InputWrapper-label) {
+    grid-column: 1;
+    margin-bottom: 0 !important;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  :global(.mantine-InputWrapper-input) {
+    grid-column: 2;
+  }
+
+  :global(.mantine-InputWrapper-error) {
+    grid-column: 2;
+    margin-top: 0.25rem;
+    margin-bottom: 0;
+  }
+}

--- a/src/app/_components/common/datepicker/DatePicker.tsx
+++ b/src/app/_components/common/datepicker/DatePicker.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import type { DateTimePickerProps } from "@mantine/dates";
+import { DateTimePicker } from "@mantine/dates";
+import styles from "./DatePicker.module.scss";
+
+export interface DatePickerProps extends Omit<DateTimePickerProps, "classNames"> {
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+  error?: string;
+}
+
+export default function DatePicker({
+  label,
+  placeholder,
+  required = false,
+  error,
+  valueFormat = "DD MMM YYYY hh:mm A",
+  ...props
+}: DatePickerProps) {
+  return (
+    <div className={styles.formRow}>
+      <DateTimePicker
+        label={label}
+        placeholder={placeholder}
+        withAsterisk={required}
+        valueFormat={valueFormat}
+        error={error}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/src/app/_components/common/datepicker/DatePicker.tsx
+++ b/src/app/_components/common/datepicker/DatePicker.tsx
@@ -4,21 +4,54 @@ import type { DateTimePickerProps } from "@mantine/dates";
 import { DateTimePicker } from "@mantine/dates";
 import styles from "./DatePicker.module.scss";
 
-export interface DatePickerProps extends Omit<DateTimePickerProps, "classNames"> {
+export interface DatePickerProps extends Omit<DateTimePickerProps, "value" | "onChange"> {
   label: string;
   placeholder?: string;
   required?: boolean;
   error?: string;
+  value?: string | null;
+  onChange?: (value: string | null) => void;
 }
 
+/**
+ * DatePicker component
+ *
+ * Pick a date and time, returns an iso string value
+ *
+ * @example
+ * const [date, setDate] = useState<string | null>(null);
+ *
+ * <DatePicker
+ *   label="Departure Time"
+ *   value={date}
+ *   onChange={setDate}
+ * />
+ *
+ */
 export default function DatePicker({
   label,
   placeholder,
   required = false,
   error,
   valueFormat = "DD MMM YYYY hh:mm A",
+  value,
+  onChange,
   ...props
 }: DatePickerProps) {
+  // Convert ISO string to Date object for Mantine
+  const mantineValue = value ? new Date(value) : null;
+
+  // Convert to iso string
+  const handleChange = (mantineValue: string | null) => {
+    if (!mantineValue) {
+      onChange?.(null);
+      return;
+    }
+
+    const isoString = new Date(mantineValue).toISOString();
+    onChange?.(isoString);
+  };
+
   return (
     <div className={styles.formRow}>
       <DateTimePicker
@@ -27,6 +60,12 @@ export default function DatePicker({
         withAsterisk={required}
         valueFormat={valueFormat}
         error={error}
+        value={mantineValue}
+        onChange={handleChange}
+        timePickerProps={{
+          withDropdown: true,
+          popoverProps: { withinPortal: false },
+        }}
         {...props}
       />
     </div>

--- a/src/app/_components/common/datepicker/DatePicker.tsx
+++ b/src/app/_components/common/datepicker/DatePicker.tsx
@@ -39,16 +39,26 @@ export default function DatePicker({
   ...props
 }: DatePickerProps) {
   // Convert ISO string to Date object for Mantine
-  const mantineValue = value ? new Date(value) : null;
+  let mantineValue = value ? new Date(value) : null;
+
+  // Validate the date
+  if (mantineValue && isNaN(mantineValue.getTime())) {
+    console.warn("Invalid ISO string provided to DatePicker:", value);
+    mantineValue = null;
+  }
 
   // Convert to iso string
-  const handleChange = (mantineValue: string | null) => {
+  const handleChange = (mantineValue: Date | string | null) => {
     if (!mantineValue) {
       onChange?.(null);
       return;
     }
 
-    const isoString = new Date(mantineValue).toISOString();
+    // Handle both Date objects and strings from Mantine
+    const isoString =
+      mantineValue instanceof Date
+        ? mantineValue.toISOString()
+        : new Date(mantineValue).toISOString();
     onChange?.(isoString);
   };
 
@@ -57,6 +67,7 @@ export default function DatePicker({
       <DateTimePicker
         label={label}
         placeholder={placeholder}
+        {...props}
         withAsterisk={required}
         valueFormat={valueFormat}
         error={error}
@@ -66,7 +77,6 @@ export default function DatePicker({
           withDropdown: true,
           popoverProps: { withinPortal: false },
         }}
-        {...props}
       />
     </div>
   );

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -1,14 +1,22 @@
 "use client";
 
 import { Divider, Group, Stack, Title } from "@mantine/core";
+import { useState } from "react";
 import Chevron from "@/assets/icons/chevron";
 import Face from "@/assets/icons/face";
 import Location from "@/assets/icons/location";
 import Plus from "@/assets/icons/plus";
 import Button from "../_components/common/button/Button";
 import IconButton from "../_components/common/button/IconButton";
+import DatePicker from "../_components/common/datepicker/DatePicker";
 
 export default function StylesPage() {
+  const [date, setDate] = useState<string | null>(null);
+
+  const handleDateChange = (value: string | null) => {
+    setDate(value);
+  };
+
   return (
     <Stack p="xl" gap="xl">
       <Title order={1}>Component Style Guide</Title>
@@ -66,6 +74,31 @@ export default function StylesPage() {
             Custom Height
             <IconButton icon={<Plus />} ariaLabel="plus" transparent /> transparent
           </Group>
+        </Stack>
+      </Stack>
+
+      <Divider />
+
+      <Stack gap="md">
+        <Title order={2}>Date Pickers</Title>
+
+        <Stack gap="sm">
+          <Title order={3} size="h4">
+            DatePicker
+          </Title>
+          <Group>
+            <DatePicker
+              label="Departure Time"
+              placeholder="Select date and time"
+              value={date}
+              onChange={handleDateChange}
+            />
+          </Group>
+          {date && (
+            <div>
+              <strong>Selected value:</strong> {date}
+            </div>
+          )}
         </Stack>
       </Stack>
 


### PR DESCRIPTION
Created the DatePicker component. 
- Added functionality to pick the time by clicking on the datepicker popover
- Changed the return value from a Date object to an iso string
- Replaced the DatePicker in the agency form with the new component
- Added the DatePicker component to the style-guide page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced separate start/end date-time fields with a single unified Date Picker for transport scheduling.
  * Added a Date Picker demo to the style guide showing live selection and value display.

* **Style**
  * Updated date picker layout and form-field alignment for a cleaner, more consistent booking form experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->