### PR TITLE
fix: bookings router to use pickup/destination endpoint names

### DIFF
--- a/src/app/debug/bookings/page.tsx
+++ b/src/app/debug/bookings/page.tsx
@@ -15,8 +15,8 @@ export default function BookingDebugPage() {
   const form = useForm({
     initialValues: {
       title: "",
-      pickupLocation: "",
-      dropoffLocation: "",
+      pickupAddress: "",
+      destinationAddress: "",
       passengerInfo: "",
       start: "",
       end: "",
@@ -27,8 +27,8 @@ export default function BookingDebugPage() {
     },
     validate: {
       title: (v) => (!v.trim() ? "Title is required" : null),
-      pickupLocation: (v) => (!v.trim() ? "Pickup required" : null),
-      dropoffLocation: (v) => (!v.trim() ? "Dropoff required" : null),
+      pickupAddress: (v) => (!v.trim() ? "Pickup required" : null),
+      destinationAddress: (v) => (!v.trim() ? "Dropoff required" : null),
       passengerInfo: (v) => (!v.trim() ? "Passenger info required" : null),
       agencyId: (v) => (!v.trim() ? "Agency ID required" : null),
       start: (v) => (!v.trim() ? "Start date/time required" : null),
@@ -135,8 +135,8 @@ export default function BookingDebugPage() {
         onSubmit={form.onSubmit((values) =>
           createMutation.mutate({
             title: values.title,
-            pickupLocation: values.pickupLocation,
-            dropoffLocation: values.dropoffLocation,
+            pickupAddress: values.pickupAddress,
+            destinationAddress: values.destinationAddress,
             passengerInfo: values.passengerInfo,
             agencyId: values.agencyId,
             startTime: values.start,
@@ -149,11 +149,11 @@ export default function BookingDebugPage() {
         className={styles.formGrid}
       >
         <TextInput withAsterisk label="Title" {...form.getInputProps("title")} />
-        <TextInput withAsterisk label="Pickup Location" {...form.getInputProps("pickupLocation")} />
+        <TextInput withAsterisk label="Pickup Address" {...form.getInputProps("pickupAddress")} />
         <TextInput
           withAsterisk
-          label="Dropoff Location"
-          {...form.getInputProps("dropoffLocation")}
+          label="Destination Address"
+          {...form.getInputProps("destinationAddress")}
         />
         <Textarea withAsterisk label="Passenger Info" {...form.getInputProps("passengerInfo")} />
         <TextInput withAsterisk label="Agency ID" {...form.getInputProps("agencyId")} />

--- a/src/server/api/routers/bookings.ts
+++ b/src/server/api/routers/bookings.ts
@@ -13,8 +13,8 @@ export const bookingsRouter = createTRPCRouter({
       z
         .object({
           title: z.string().min(1),
-          pickupLocation: z.string().min(1),
-          dropoffLocation: z.string().min(1),
+          pickupAddress: z.string().min(1),
+          destinationAddress: z.string().min(1),
           passengerInfo: z.string().min(1),
           agencyId: z.string().min(1),
 
@@ -41,8 +41,8 @@ export const bookingsRouter = createTRPCRouter({
 
       const bookingData: typeof bookings.$inferInsert = {
         title: input.title,
-        pickupLocation: input.pickupLocation,
-        dropoffLocation: input.dropoffLocation,
+        pickupAddress: input.pickupAddress,
+        destinationAddress: input.destinationAddress,
         passengerInfo: input.passengerInfo,
         agencyId,
         startTime: input.startTime,
@@ -119,8 +119,8 @@ export const bookingsRouter = createTRPCRouter({
       z.object({
         id: z.number(),
         title: z.string().optional(),
-        pickupLocation: z.string().optional(),
-        dropoffLocation: z.string().optional(),
+        pickupAddress: z.string().optional(),
+        destinationAddress: z.string().optional(),
         purpose: z.string().optional(),
         passengerInfo: z.string().optional(),
         driverId: z.string().optional().nullable(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed booking fields for clarity: pickupLocation → pickupAddress and dropoffLocation → destinationAddress; these are now required on booking creation and optional when updating.

* **UI**
  * Updated booking form labels and validation messages to reflect the new "Pickup Address" and "Destination Address" field names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->