### PR TITLE
SANC-43-Connect-agency-booking-form-to-trip-creation-API

### DIFF
--- a/src/app/_components/agencycomponents/agency-form.tsx
+++ b/src/app/_components/agencycomponents/agency-form.tsx
@@ -3,6 +3,7 @@
 import { Box, Divider, Stack, Textarea, TextInput } from "@mantine/core";
 import { DateTimePicker } from "@mantine/dates";
 import type { UseFormReturnType } from "@mantine/form";
+import dayjs from "dayjs";
 import classes from "./agency-form.module.scss";
 
 interface AgencyBookingForm {
@@ -24,30 +25,6 @@ interface AgencyFormProps {
 
 export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => {
   const now = new Date();
-
-  // Helper function to convert Date or string to local ISO string (preserves local time, no UTC conversion)
-  const toLocalISOString = (value: Date | string | null): string => {
-    if (!value) return "";
-
-    // Normalize input to Date object
-    let date: Date;
-    if (typeof value === "string") {
-      date = new Date(value);
-      // Check if the parsed date is invalid
-      if (Number.isNaN(date.getTime())) return "";
-    } else {
-      date = value;
-    }
-
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    const hours = String(date.getHours()).padStart(2, "0");
-    const minutes = String(date.getMinutes()).padStart(2, "0");
-    const seconds = String(date.getSeconds()).padStart(2, "0");
-
-    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
-  };
 
   return (
     <Stack gap="lg">
@@ -109,14 +86,24 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
             label="Start time"
             placeholder="Select start date and time"
             minDate={now}
-            valueFormat="YYYY-MM-DDTHH:mm:ss"
+            valueFormat="MMM DD, YYYY hh:mm A"
             value={form.values.startTime ? new Date(form.values.startTime) : null}
             onChange={(value) => {
-              const localISOString = toLocalISOString(value);
-              form.setFieldValue("startTime", localISOString);
+              if (!value) {
+                form.setFieldValue("startTime", "");
+                return;
+              }
+              const isoString = dayjs(value).toISOString();
+              console.log("Start Time - parsed:", isoString);
+              console.log("Start Time - after parsing:", new Date(isoString));
+              console.log(
+                "Start Time - show local time:",
+                dayjs(isoString).format("YYYY-MM-DD hh:mm A"),
+              );
+              form.setFieldValue("startTime", isoString);
 
-              // to reset the end time if it's invalid
-              if (localISOString && form.values.endTime && form.values.endTime <= localISOString) {
+              if (isoString && form.values.endTime && form.values.endTime <= isoString) {
+                // to reset the end time if it's invalid
                 form.setFieldValue("endTime", "");
               }
             }}
@@ -135,11 +122,21 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
             label="End time"
             placeholder="Select end date and time"
             minDate={form.values.startTime ? new Date(form.values.startTime) : now}
-            valueFormat="YYYY-MM-DDTHH:mm:ss"
+            valueFormat="MMM DD, YYYY hh:mm A"
             value={form.values.endTime ? new Date(form.values.endTime) : null}
             onChange={(value) => {
-              const localISOString = toLocalISOString(value);
-              form.setFieldValue("endTime", localISOString);
+              if (!value) {
+                form.setFieldValue("endTime", "");
+                return;
+              }
+              const isoString = dayjs(value).toISOString();
+              console.log("End Time - parsed:", isoString);
+              console.log("End Time - after parsing:", new Date(isoString));
+              console.log(
+                "End Time - show local time:",
+                dayjs(isoString).format("YYYY-MM-DD hh:mm A"),
+              );
+              form.setFieldValue("endTime", isoString);
             }}
             disabled={!form.values.startTime}
             timePickerProps={{

--- a/src/app/_components/agencycomponents/agency-form.tsx
+++ b/src/app/_components/agencycomponents/agency-form.tsx
@@ -25,9 +25,19 @@ interface AgencyFormProps {
 export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => {
   const now = new Date();
 
-  // Helper function to convert Date to local ISO string (preserves local time, no UTC conversion)
-  const toLocalISOString = (date: Date | null): string => {
-    if (!date) return "";
+  // Helper function to convert Date or string to local ISO string (preserves local time, no UTC conversion)
+  const toLocalISOString = (value: Date | string | null): string => {
+    if (!value) return "";
+
+    // Normalize input to Date object
+    let date: Date;
+    if (typeof value === "string") {
+      date = new Date(value);
+      // Check if the parsed date is invalid
+      if (Number.isNaN(date.getTime())) return "";
+    } else {
+      date = value;
+    }
 
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, "0");

--- a/src/app/_components/agencycomponents/agency-form.tsx
+++ b/src/app/_components/agencycomponents/agency-form.tsx
@@ -25,6 +25,20 @@ interface AgencyFormProps {
 export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => {
   const now = new Date();
 
+  // Helper function to convert Date to local ISO string (preserves local time, no UTC conversion)
+  const toLocalISOString = (date: Date | null): string => {
+    if (!date) return "";
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    const hours = String(date.getHours()).padStart(2, "0");
+    const minutes = String(date.getMinutes()).padStart(2, "0");
+    const seconds = String(date.getSeconds()).padStart(2, "0");
+
+    return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  };
+
   return (
     <Stack gap="lg">
       <div className={classes.formRow}>
@@ -85,12 +99,14 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
             label="Start time"
             placeholder="Select start date and time"
             minDate={now}
-            value={form.values.startTime}
+            valueFormat="YYYY-MM-DDTHH:mm:ss"
+            value={form.values.startTime ? new Date(form.values.startTime) : null}
             onChange={(value) => {
-              form.setFieldValue("startTime", value || "");
+              const localISOString = toLocalISOString(value);
+              form.setFieldValue("startTime", localISOString);
 
               // to reset the end time if it's invalid
-              if (value && form.values.endTime && form.values.endTime <= value) {
+              if (localISOString && form.values.endTime && form.values.endTime <= localISOString) {
                 form.setFieldValue("endTime", "");
               }
             }}
@@ -108,9 +124,13 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
             withAsterisk
             label="End time"
             placeholder="Select end date and time"
-            minDate={form.values.startTime ?? now}
-            value={form.values.endTime}
-            onChange={(value) => form.setFieldValue("endTime", value || "")}
+            minDate={form.values.startTime ? new Date(form.values.startTime) : now}
+            valueFormat="YYYY-MM-DDTHH:mm:ss"
+            value={form.values.endTime ? new Date(form.values.endTime) : null}
+            onChange={(value) => {
+              const localISOString = toLocalISOString(value);
+              form.setFieldValue("endTime", localISOString);
+            }}
             disabled={!form.values.startTime}
             timePickerProps={{
               withDropdown: true,

--- a/src/app/_components/agencycomponents/agency-form.tsx
+++ b/src/app/_components/agencycomponents/agency-form.tsx
@@ -94,12 +94,6 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
                 return;
               }
               const isoString = dayjs(value).toISOString();
-              console.log("Start Time - parsed:", isoString);
-              console.log("Start Time - after parsing:", new Date(isoString));
-              console.log(
-                "Start Time - show local time:",
-                dayjs(isoString).format("YYYY-MM-DD hh:mm A"),
-              );
               form.setFieldValue("startTime", isoString);
 
               if (isoString && form.values.endTime && form.values.endTime <= isoString) {
@@ -130,12 +124,6 @@ export const AgencyForm = ({ form, destinationAddressRef }: AgencyFormProps) => 
                 return;
               }
               const isoString = dayjs(value).toISOString();
-              console.log("End Time - parsed:", isoString);
-              console.log("End Time - after parsing:", new Date(isoString));
-              console.log(
-                "End Time - show local time:",
-                dayjs(isoString).format("YYYY-MM-DD hh:mm A"),
-              );
               form.setFieldValue("endTime", isoString);
             }}
             disabled={!form.values.startTime}

--- a/src/app/_components/agencycomponents/agency-interactive-area.tsx
+++ b/src/app/_components/agencycomponents/agency-interactive-area.tsx
@@ -22,20 +22,32 @@ interface Props {
 const GOOGLE_MAPS_LIBRARIES_ARRAY: Libraries = ["places"]; //Add more to this array if you need to import more libraries from the API
 const CHERRY_RED = "#A03145";
 
-export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: Props) => {
+export const BookingInteractiveArea = ({
+  initialViewMode = ViewMode.CALENDAR,
+}: Props) => {
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   const [showBookingModal, setShowBookingModal] = useState<boolean>(false);
-  // eventually this loading state will be replacted with a tanstack mutation loading state
-  const [loading, setLoading] = useState<boolean>(false);
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [isDayView, setIsDayView] = useState<boolean>(false);
-  const [validationAddressGood, setValidationAddressGood] = useState<boolean>(false);
+  const [validationAddressGood, setValidationAddressGood] =
+    useState<boolean>(false);
 
   const {
     data: bookings,
     isLoading: isLoadingBookings,
     isError: isErrorBookings,
   } = api.bookings.getAll.useQuery();
+  const createBookingMutation = api.trip.create.useMutation({
+    onSuccess: () => {
+      notify.success("Booking successfully created");
+      form.reset();
+      setShowBookingModal(false);
+      setValidationAddressGood(false);
+    },
+    onError: (error) => {
+      notify.error(error.message || "Failed to create a booking");
+    },
+  });
 
   //Define a variable that react will reassign its value on runtime
   //Starts off as null but will equal (through inputElement.current) an HTML input element when assigned at runtime
@@ -63,11 +75,18 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
 
     validate: {
       title: (value) => (value.trim().length > 0 ? null : "Title is required"),
-      residentName: (value) => (value.trim().length > 0 ? null : "Resident name is required"),
-      startTime: (value) => (value.trim().length > 0 ? null : "Date and time is required"),
-      endTime: (value) => (value.trim().length > 0 ? null : "Date and time is required"),
-      purpose: (value) => (value.trim().length > 0 ? null : "Purpose is required"),
-      pickupAddress: (value) => (value.trim().length > 0 ? null : "Pickup address is required"),
+      residentName: (value) =>
+        value.trim().length > 0 ? null : "Resident name is required",
+      contactInfo: (value) =>
+        value.trim().length > 0 ? null : "Contact info is required",
+      startTime: (value) =>
+        value.trim().length > 0 ? null : "Date and time is required",
+      endTime: (value) =>
+        value.trim().length > 0 ? null : "Date and time is required",
+      purpose: (value) =>
+        value.trim().length > 0 ? null : "Purpose is required",
+      pickupAddress: (value) =>
+        value.trim().length > 0 ? null : "Pickup address is required",
       destinationAddress: (value) =>
         value.trim().length > 0 ? null : "Destination address is required",
     },
@@ -77,14 +96,21 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
   // biome-ignore lint: inputElement.current does change and needs to be changed in order for useEffect() to run
   useEffect(() => {
     //Do not run the code within the useEffect if the api or mantine form hasn't fully loaded
-    if (!isLoaded || google.maps.places === null || inputElement.current === null) {
+    if (
+      !isLoaded ||
+      google.maps.places === null ||
+      inputElement.current === null
+    ) {
       return;
     }
 
     //Make the google auto complete element and attach it to inputElement (requires an HTML input element to mount to)
-    const googleAutoCompleteElement = new google.maps.places.Autocomplete(inputElement.current, {
-      types: ["address"],
-    });
+    const googleAutoCompleteElement = new google.maps.places.Autocomplete(
+      inputElement.current,
+      {
+        types: ["address"],
+      }
+    );
 
     //Places bounds on what locations google will suggest
     googleAutoCompleteElement.setComponentRestrictions({
@@ -120,54 +146,34 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
     };
   }, [inputElement.current]);
 
-  const handleConfirm = async () => {
-    setLoading(true);
+  const handleConfirm = () => {
     const validation = form.validate();
     const hasErrors = Object.keys(validation.errors).length > 0;
 
     if (hasErrors) {
       notify.error("Please fix the errors in the form before submitting");
-      setLoading(false);
       return;
     }
 
-    const values = form.values;
-    console.log("submit", values);
+    if (!validationAddressGood) {
+      form.setFieldError(
+        "destinationAddress",
+        "Please select a valid address from the dropdown"
+      );
+      return;
+    }
 
-    // enter an actual api call here like a tanstack mutation
-    // when calling the backend to verify form and update the db, must manually pass the destination address
-    // do NOT use the mantine field form as it will not contain the destination address
-    // use instead -> [inputElement.current?.value || ""]
-    // see the below code for a sample usage of calling the backend to verify destination address
-    /*
-      //Define backend endpoint (if you need to directly call this api - probably won't though, put at the top of the file, under useStates)
-      const validateDestinationAddressAPI = api.form.validateDestinationAddress.useMutation();
-
-      if (validationAddressGood) {
-        //Call the backend
-        const result = await validateDestinationAddressAPI.mutateAsync({
-          regionCode: "ca",
-          destinationAddress: [inputElement.current?.value || ""],
-        });
-
-        //Evaluate the result from the back-end
-        if (result === null) {
-          //Manually adds an error field to the mantine form
-          form.setFieldError("destinationAddress", "Destination address is too vague");
-        } else{
-          // use -> result passed from funct call as address that goes into db
-          // update db with result var
-          console.log("Backend is happy with input");
-        }
-      }
-    */
-
-    setTimeout(() => {
-      setLoading(false);
-      setShowBookingModal(false);
-      notify.success("Booking successfully created");
-      form.reset();
-    }, 2000);
+    createBookingMutation.mutate({
+      title: form.values.title,
+      residentName: form.values.residentName,
+      contactInfo: form.values.contactInfo,
+      additionalInfo: form.values.additionalInfo,
+      pickupAddress: form.values.pickupAddress,
+      destinationAddress: inputElement.current?.value || "",
+      startTime: new Date(form.values.startTime).toISOString(),
+      endTime: new Date(form.values.endTime).toISOString(),
+      purpose: form.values.purpose,
+    });
   };
 
   //If the script hasn't loaded yet, don't render anything until it does
@@ -226,7 +232,7 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
         size="xl"
         showDefaultFooter
         confirmText="Confirm Booking"
-        loading={loading}
+        loading={createBookingMutation.isPending}
       >
         <AgencyForm form={form} destinationAddressRef={inputElement} />
       </Modal>

--- a/src/app/_components/agencycomponents/agency-interactive-area.tsx
+++ b/src/app/_components/agencycomponents/agency-interactive-area.tsx
@@ -11,8 +11,8 @@ import { env } from "@/env";
 import { notify } from "@/lib/notifications";
 import { api } from "@/trpc/react";
 import { ViewMode } from "@/types/types";
-import CalendarView from "../agencypage/calendar-view";
 import { validateStringLength, validateTimeRange } from "@/types/validation";
+import CalendarView from "../agencypage/calendar-view";
 import TableView from "../agencypage/table-view";
 import styles from "./agency-interactive-area.module.scss";
 
@@ -183,8 +183,8 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
       additionalInfo: form.values.additionalInfo,
       pickupAddress: form.values.pickupAddress,
       destinationAddress: inputElement.current?.value || "",
-      startTime: startDate.toISOString(),
-      endTime: endDate.toISOString(),
+      startTime: form.values.startTime,
+      endTime: form.values.endTime,
       purpose: form.values.purpose,
     });
   };

--- a/src/app/_components/agencycomponents/agency-interactive-area.tsx
+++ b/src/app/_components/agencycomponents/agency-interactive-area.tsx
@@ -23,15 +23,12 @@ interface Props {
 const GOOGLE_MAPS_LIBRARIES_ARRAY: Libraries = ["places"]; //Add more to this array if you need to import more libraries from the API
 const CHERRY_RED = "#A03145";
 
-export const BookingInteractiveArea = ({
-  initialViewMode = ViewMode.CALENDAR,
-}: Props) => {
+export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: Props) => {
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
   const [showBookingModal, setShowBookingModal] = useState<boolean>(false);
   const [currentDate, setCurrentDate] = useState<Date>(new Date());
   const [isDayView, setIsDayView] = useState<boolean>(false);
-  const [validationAddressGood, setValidationAddressGood] =
-    useState<boolean>(false);
+  const [validationAddressGood, setValidationAddressGood] = useState<boolean>(false);
 
   const {
     data: bookings,
@@ -100,21 +97,14 @@ export const BookingInteractiveArea = ({
   // biome-ignore lint: inputElement.current does change and needs to be changed in order for useEffect() to run
   useEffect(() => {
     //Do not run the code within the useEffect if the api or mantine form hasn't fully loaded
-    if (
-      !isLoaded ||
-      google.maps.places === null ||
-      inputElement.current === null
-    ) {
+    if (!isLoaded || google.maps.places === null || inputElement.current === null) {
       return;
     }
 
     //Make the google auto complete element and attach it to inputElement (requires an HTML input element to mount to)
-    const googleAutoCompleteElement = new google.maps.places.Autocomplete(
-      inputElement.current,
-      {
-        types: ["address"],
-      }
-    );
+    const googleAutoCompleteElement = new google.maps.places.Autocomplete(inputElement.current, {
+      types: ["address"],
+    });
 
     //Places bounds on what locations google will suggest
     googleAutoCompleteElement.setComponentRestrictions({
@@ -160,10 +150,7 @@ export const BookingInteractiveArea = ({
     }
 
     if (!validationAddressGood) {
-      form.setFieldError(
-        "destinationAddress",
-        "Please select a valid address from the dropdown"
-      );
+      form.setFieldError("destinationAddress", "Please select a valid address from the dropdown");
       return;
     }
 

--- a/src/app/_components/agencycomponents/agency-interactive-area.tsx
+++ b/src/app/_components/agencycomponents/agency-interactive-area.tsx
@@ -82,11 +82,18 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
         if (value.trim().length === 0) return null;
         return validateStringLength(value, 0, 500, "Additional information");
       },
-      startTime: (value) => (value.trim().length > 0 ? null : "Date and time is required"),
+      startTime: (value) => {
+        // First check if required
+        if (value.trim().length === 0) return "Date and time is required";
+        // Then validate date format
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return "Invalid date format";
+        return null;
+      },
       endTime: (value, values) => {
         // First check if required
         if (value.trim().length === 0) return "Date and time is required";
-        // Then validate time range
+        // Then validate time range (this also validates date format)
         return validateTimeRange(values.startTime, value);
       },
       purpose: (value) => validateStringLength(value, 1, 500, "Purpose of transport"),
@@ -156,6 +163,19 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
       return;
     }
 
+    const startDate = new Date(form.values.startTime);
+    const endDate = new Date(form.values.endTime);
+
+    if (Number.isNaN(startDate.getTime())) {
+      form.setFieldError("startTime", "Invalid date format");
+      return;
+    }
+
+    if (Number.isNaN(endDate.getTime())) {
+      form.setFieldError("endTime", "Invalid date format");
+      return;
+    }
+
     createBookingMutation.mutate({
       title: form.values.title,
       residentName: form.values.residentName,
@@ -163,8 +183,8 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
       additionalInfo: form.values.additionalInfo,
       pickupAddress: form.values.pickupAddress,
       destinationAddress: inputElement.current?.value || "",
-      startTime: new Date(form.values.startTime).toISOString(),
-      endTime: new Date(form.values.endTime).toISOString(),
+      startTime: startDate.toISOString(),
+      endTime: endDate.toISOString(),
       purpose: form.values.purpose,
     });
   };

--- a/src/app/_components/agencycomponents/agency-interactive-area.tsx
+++ b/src/app/_components/agencycomponents/agency-interactive-area.tsx
@@ -12,6 +12,7 @@ import { notify } from "@/lib/notifications";
 import { api } from "@/trpc/react";
 import { ViewMode } from "@/types/types";
 import CalendarView from "../agencypage/calendar-view";
+import { validateStringLength, validateTimeRange } from "@/types/validation";
 import TableView from "../agencypage/table-view";
 import styles from "./agency-interactive-area.module.scss";
 
@@ -74,21 +75,24 @@ export const BookingInteractiveArea = ({
     },
 
     validate: {
-      title: (value) => (value.trim().length > 0 ? null : "Title is required"),
-      residentName: (value) =>
-        value.trim().length > 0 ? null : "Resident name is required",
-      contactInfo: (value) =>
-        value.trim().length > 0 ? null : "Contact info is required",
-      startTime: (value) =>
-        value.trim().length > 0 ? null : "Date and time is required",
-      endTime: (value) =>
-        value.trim().length > 0 ? null : "Date and time is required",
-      purpose: (value) =>
-        value.trim().length > 0 ? null : "Purpose is required",
-      pickupAddress: (value) =>
-        value.trim().length > 0 ? null : "Pickup address is required",
-      destinationAddress: (value) =>
-        value.trim().length > 0 ? null : "Destination address is required",
+      title: (value) => validateStringLength(value, 1, 150, "Booking name"),
+      residentName: (value) => validateStringLength(value, 1, 100, "Resident name"),
+      phoneNumber: (value) => validateStringLength(value, 1, 150, "Contact information"),
+      additionalInfo: (value) => {
+        // Optional field, only validate max length if provided
+        if (value.trim().length === 0) return null;
+        return validateStringLength(value, 0, 500, "Additional information");
+      },
+      startTime: (value) => (value.trim().length > 0 ? null : "Date and time is required"),
+      endTime: (value, values) => {
+        // First check if required
+        if (value.trim().length === 0) return "Date and time is required";
+        // Then validate time range
+        return validateTimeRange(values.startTime, value);
+      },
+      purpose: (value) => validateStringLength(value, 1, 500, "Purpose of transport"),
+      pickupAddress: (value) => validateStringLength(value, 1, 300, "Pickup address"),
+      destinationAddress: (value) => validateStringLength(value, 1, 300, "Destination address"),
     },
   });
 
@@ -166,7 +170,7 @@ export const BookingInteractiveArea = ({
     createBookingMutation.mutate({
       title: form.values.title,
       residentName: form.values.residentName,
-      contactInfo: form.values.contactInfo,
+      phoneNumber: form.values.phoneNumber,
       additionalInfo: form.values.additionalInfo,
       pickupAddress: form.values.pickupAddress,
       destinationAddress: inputElement.current?.value || "",

--- a/src/app/_components/agencycomponents/agency-interactive-area.tsx
+++ b/src/app/_components/agencycomponents/agency-interactive-area.tsx
@@ -30,6 +30,7 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
   const [isDayView, setIsDayView] = useState<boolean>(false);
   const [validationAddressGood, setValidationAddressGood] = useState<boolean>(false);
 
+  const utils = api.useUtils();
   const {
     data: bookings,
     isLoading: isLoadingBookings,
@@ -41,6 +42,7 @@ export const BookingInteractiveArea = ({ initialViewMode = ViewMode.CALENDAR }: 
       form.reset();
       setShowBookingModal(false);
       setValidationAddressGood(false);
+      void utils.bookings.getAll.invalidate();
     },
     onError: (error) => {
       notify.error(error.message || "Failed to create a booking");

--- a/src/app/_components/common/datepicker/DatePicker.tsx
+++ b/src/app/_components/common/datepicker/DatePicker.tsx
@@ -42,7 +42,7 @@ export default function DatePicker({
   let mantineValue = value ? new Date(value) : null;
 
   // Validate the date
-  if (mantineValue && isNaN(mantineValue.getTime())) {
+  if (mantineValue && Number.isNaN(mantineValue.getTime())) {
     console.warn("Invalid ISO string provided to DatePicker:", value);
     mantineValue = null;
   }

--- a/src/app/_components/common/exportToCSVButton/ExportToCSVButton.tsx
+++ b/src/app/_components/common/exportToCSVButton/ExportToCSVButton.tsx
@@ -12,7 +12,7 @@ import { notify } from "@/lib/notifications";
  * @param agGrid Reference to an AgGrid
  * @returns A function that initiates CSV file download when called
  */
-export function defaultFunction(agGrid: RefObject<AgGridReact | null>): (...args: any[]) => void {
+export function defaultFunction(agGrid: RefObject<AgGridReact | null>): () => void {
   return () => {
     if (agGrid.current !== null) {
       agGrid.current.api.exportDataAsCsv();
@@ -23,7 +23,7 @@ export function defaultFunction(agGrid: RefObject<AgGridReact | null>): (...args
 }
 
 interface ExportToCSVButtonProps {
-  downloadFunction?: (...args: any[]) => void; //Variable is of type function
+  downloadFunction?: () => void; //Variable is of type function
 }
 
 export default function ExportToCSVButton({ downloadFunction }: ExportToCSVButtonProps) {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -5,7 +5,7 @@ import { Role } from "@/types/types";
 import styles from "./admin-layout.module.scss";
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  const session = await requireRole([Role.ADMIN]);
+  const _session = await requireRole([Role.ADMIN]);
 
   return (
     <HydrateClient>

--- a/src/app/debug/bookings/page.tsx
+++ b/src/app/debug/bookings/page.tsx
@@ -4,7 +4,6 @@ import { Button, Divider, Group, Select, Textarea, TextInput } from "@mantine/co
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import { useState } from "react";
-import { authClient } from "@/lib/auth-client";
 import { api } from "@/trpc/react";
 import { ALL_BOOKING_STATUSES, BookingStatus, type BookingStatusValue } from "@/types/types";
 import styles from "./BookingDebugPage.module.scss";

--- a/src/server/api/routers/bookings.ts
+++ b/src/server/api/routers/bookings.ts
@@ -122,11 +122,11 @@ export const bookingsRouter = createTRPCRouter({
       let startAndEndDateErrorMessage = "Invalid: ";
 
       if (!(isoTimeRegex.test(startDate) || isoTimeRegexFourDigitYears.test(startDate))) {
-        startAndEndDateErrorMessage = startAndEndDateErrorMessage + "Start Date ";
+        startAndEndDateErrorMessage = `${startAndEndDateErrorMessage}Start Date `;
       }
 
       if (!(isoTimeRegex.test(endDate) || isoTimeRegexFourDigitYears.test(endDate))) {
-        startAndEndDateErrorMessage = startAndEndDateErrorMessage + "End Date ";
+        startAndEndDateErrorMessage = `${startAndEndDateErrorMessage}End Date `;
       }
 
       if (startAndEndDateErrorMessage !== "Invalid: ") {

--- a/src/server/api/routers/trip.ts
+++ b/src/server/api/routers/trip.ts
@@ -9,7 +9,7 @@ export const tripRouter = createTRPCRouter({
       z.object({
         title: z.string().min(1, "Title is required"),
         residentName: z.string().min(1, "Resident name is required"),
-        contactInfo: z.string().min(1, "Contact info is required"),
+        phoneNumber: z.string().min(1, "Phone number is required"),
         additionalInfo: z.string().optional(),
         // Requires ISO 8601 String
         startTime: z.string().datetime(),
@@ -24,7 +24,8 @@ export const tripRouter = createTRPCRouter({
         title: input.title,
         pickupAddress: input.pickupAddress,
         destinationAddress: input.destinationAddress,
-        passengerInfo: `${input.residentName} ${input.contactInfo} ${input.additionalInfo ? `${input.additionalInfo}` : ""}`,
+        passengerInfo: `${input.residentName} ${input.additionalInfo ? `${input.additionalInfo}` : ""}`,
+        phoneNumber: input.phoneNumber,
         agencyId: ctx.session.user.id,
         purpose: input.purpose,
         createdBy: ctx.session.user.id,

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -52,11 +52,11 @@ export const validateTimeRange = (startTime: string, endTime: string): string | 
   const end = new Date(endTime);
 
   // Validate that date parsing succeeded
-  if (isNaN(start.getTime())) {
+  if (Number.isNaN(start.getTime())) {
     return "Invalid start time format";
   }
 
-  if (isNaN(end.getTime())) {
+  if (Number.isNaN(end.getTime())) {
     return "Invalid end time format";
   }
 

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -51,6 +51,15 @@ export const validateTimeRange = (startTime: string, endTime: string): string | 
   const start = new Date(startTime);
   const end = new Date(endTime);
 
+  // Validate that date parsing succeeded
+  if (isNaN(start.getTime())) {
+    return "Invalid start time format";
+  }
+
+  if (isNaN(end.getTime())) {
+    return "Invalid end time format";
+  }
+
   if (end <= start) {
     return "End time must be after start time";
   }

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -8,3 +8,52 @@ export const passwordSchema = z
   .regex(/[0-9]/, "Password must contain at least one number");
 
 export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validates a string's length with both minimum and maximum constraints.
+ * @param value - The string value to validate
+ * @param minLength - Minimum required length (default: 1)
+ * @param maxLength - Maximum allowed length
+ * @param fieldName - Human-readable field name for error messages
+ * @returns Error message string or null if valid
+ */
+export const validateStringLength = (
+  value: string,
+  minLength: number,
+  maxLength: number,
+  fieldName: string,
+): string | null => {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue.length < minLength) {
+    return `${fieldName} is required`;
+  }
+
+  if (trimmedValue.length > maxLength) {
+    return `${fieldName} cannot exceed ${maxLength} characters`;
+  }
+
+  return null;
+};
+
+/**
+ * Validates that an end time is after a start time.
+ * @param startTime - ISO date string for start time
+ * @param endTime - ISO date string for end time
+ * @returns Error message string or null if valid
+ */
+export const validateTimeRange = (startTime: string, endTime: string): string | null => {
+  // Don't validate if either field is empty (let required validation handle that)
+  if (!startTime || !endTime) {
+    return null;
+  }
+
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  if (end <= start) {
+    return "End time must be after start time";
+  }
+
+  return null;
+};

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -9,6 +9,13 @@ export const passwordSchema = z
 
 export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+export const nameRegex =
+  /^(?!.*\s{2})[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9]$/;
+
+export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-07:00$/; //ISO timestamp regex in MST for 5+ digit years
+
+export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-07:00$/; //ISO timestamp regex in MST for 4 digit years
+
 /**
  * Validates a string's length with both minimum and maximum constraints.
  * @param value - The string value to validate


### PR DESCRIPTION
The agency booking form now uses the trip creation API through a TanStack Query Mutation, this also takes care of loading/error states, and success notifications. Form values are mapped to the API format with proper validation, including Google Maps address verification and datetime conversion. The form automatically resets after successful submission.
Key change:
- Connected form submission to `api.trip.create` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Google Places address autocomplete for bookings (CA-restricted).
  * Booking submission now uses mutation-driven loading and includes explicit phone number support.
  * New input validation helpers for string length and time-range checks.

* **Bug Fixes**
  * Expanded, clearer validation for names, phone, addresses, and times.
  * Improved date/time picker handling and stricter NaN/date validation.

* **Chores**
  * Removed an unused import; minor API/prop tightening and small cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->