### PR TITLE
SANC 70: Remake login page

### DIFF
--- a/src/app/login/Login.module.scss
+++ b/src/app/login/Login.module.scss
@@ -1,5 +1,10 @@
 @use "@/styles/variables" as *;
 
+/*Variables in this file*/
+$text-size: 13px;
+$text-line-height: 1;
+
+/*Styles*/
 .background {
   display: flex;
   justify-content: center;
@@ -20,4 +25,42 @@
   width: 100%;
   justify-content: center;
   align-items: center;
+}
+
+.title {
+  text-align: center;
+  font-size: 22px;
+  padding-top: 20px;
+  padding-bottom: 5px;
+  margin-bottom: 16px;
+}
+
+.bottomText {
+  text-align: center;
+  line-height: $text-line-height;
+}
+
+.dontHaveAcc {
+  font-size: $text-size;
+  color: $color-cobalt-blue;
+  line-height: $text-line-height;
+}
+
+.contactAdmin {
+  @extend .dontHaveAcc;
+  text-decoration: underline;
+}
+
+.forgotPass {
+  color: $color-cobalt-blue;
+  font-size: $text-size;
+  padding-top: 3.5px;
+  padding-bottom: 4px;
+  line-height: $text-line-height;
+}
+
+.form {
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
+  padding: 32px;
+  border-radius: 8px;
 }

--- a/src/app/login/Login.module.scss
+++ b/src/app/login/Login.module.scss
@@ -40,23 +40,21 @@ $text-line-height: 1;
   line-height: $text-line-height;
 }
 
-.dontHaveAcc {
+.links {
   font-size: $text-size;
   color: $color-cobalt-blue;
   line-height: $text-line-height;
 }
 
 .contactAdmin {
-  @extend .dontHaveAcc;
+  @extend .links;
   text-decoration: underline;
 }
 
 .forgotPass {
-  color: $color-cobalt-blue;
-  font-size: $text-size;
-  padding-top: 3.5px;
-  padding-bottom: 4px;
-  line-height: $text-line-height;
+  @extend .links;
+  width: fit-content;
+  white-space: nowrap;
 }
 
 .form {

--- a/src/app/login/Login.module.scss
+++ b/src/app/login/Login.module.scss
@@ -1,0 +1,23 @@
+@use "@/styles/variables" as *;
+
+.background {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background-image: url("/images/skyline.jpg");
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+
+  @media (max-height: 535px) {
+    height: 535px;
+  }
+}
+
+.logo {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -56,13 +56,13 @@ export default function LoginPage() {
   return (
     <div className={ui.background}>
       <div className={styles.container}>
-        <Paper shadow="0px 0px 10px rgba(0, 0, 0, 0.25)" p="xl" radius="md">
+        <Paper className={ui.form}>
           <div className={ui.logo}>
-            <SalvationLogo></SalvationLogo>
-            <AlbertaLogo></AlbertaLogo>
+            <SalvationLogo />
+            <AlbertaLogo />
           </div>
 
-          <Title order={1} size="22px" ta="center" pt="20px" pb="5px" mb="md">
+          <Title order={1} className={ui.title}>
             Log in to the Navigation Centre
           </Title>
 
@@ -83,24 +83,22 @@ export default function LoginPage() {
                 {...form.getInputProps("password")}
               />
 
-              <Text size="sm" c="dimmed" ta="left">
-                <Anchor href="/forgot-password" size="13px">
-                  Forgot your password?
-                </Anchor>
-              </Text>
+              <Anchor href="/forgot-password" className={ui.forgotPass}>
+                Forgot your password?
+              </Anchor>
 
               <Button type="submit" loading={loading}>
                 Log in
               </Button>
 
-              <Text ta="center" lh="1">
-                <Text component="span" size="13px" c="#228BE6">
+              <Text className={ui.bottomText}>
+                <Text component="span" className={ui.dontHaveAcc}>
                   Don't have an account?{" "}
                 </Text>
 
-                <Text component="span" size="13px" c="dimmed" td="underline">
+                <Text component="span" className={ui.contactAdmin}>
                   {/*TODO: CHANGE CONTACT EMAIL TO SALVATION ARMY ONE ONCE KNOWN V*/}
-                  <Anchor href="mailto:changeEmail@AtSomePoint.com" size="13px">
+                  <Anchor href="mailto:changeEmail@AtSomePoint.com" className={ui.contactAdmin}>
                     Contact an administrator
                   </Anchor>
                 </Text>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -92,16 +92,14 @@ export default function LoginPage() {
               </Button>
 
               <Text className={ui.bottomText}>
-                <Text component="span" className={ui.dontHaveAcc}>
+                <Text component="span" className={ui.links}>
                   Don't have an account?{" "}
                 </Text>
 
-                <Text component="span" className={ui.contactAdmin}>
-                  {/*TODO: CHANGE CONTACT EMAIL TO SALVATION ARMY ONE ONCE KNOWN V*/}
-                  <Anchor href="mailto:changeEmail@AtSomePoint.com" className={ui.contactAdmin}>
-                    Contact an administrator
-                  </Anchor>
-                </Text>
+                {/*TODO: CHANGE CONTACT EMAIL TO SALVATION ARMY ONE ONCE KNOWN V*/}
+                <Anchor href="mailto:changeEmail@AtSomePoint.com" className={ui.contactAdmin}>
+                  Contact an administrator
+                </Anchor>
               </Text>
             </Stack>
           </form>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,8 +6,11 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import styles from "@/app/_components/common/auth-layout.module.scss";
 import Button from "@/app/_components/common/button/Button";
+import AlbertaLogo from "@/assets/icons/alberta";
+import SalvationLogo from "@/assets/icons/salvation";
 import { authClient } from "@/lib/auth-client";
 import { emailRegex } from "@/types/validation";
+import ui from "./Login.module.scss";
 
 export default function LoginPage() {
   const [loading, setLoading] = useState(false);
@@ -51,41 +54,61 @@ export default function LoginPage() {
   };
 
   return (
-    <div className={styles.container}>
-      <Paper shadow="sm" p="xl" radius="md">
-        <Title order={1} mb="md">
-          Sign In
-        </Title>
+    <div className={ui.background}>
+      <div className={styles.container}>
+        <Paper shadow="0px 0px 10px rgba(0, 0, 0, 0.25)" p="xl" radius="md">
+          <div className={ui.logo}>
+            <SalvationLogo></SalvationLogo>
+            <AlbertaLogo></AlbertaLogo>
+          </div>
 
-        <form onSubmit={form.onSubmit(handleSubmit)}>
-          <Stack gap="md">
-            <TextInput
-              label="Email"
-              placeholder="your@email.com"
-              type="email"
-              required
-              {...form.getInputProps("email")}
-            />
+          <Title order={1} size="22px" ta="center" pt="20px" pb="5px" mb="md">
+            Log in to the Navigation Centre
+          </Title>
 
-            <PasswordInput
-              label="Password"
-              placeholder="Your password"
-              required
-              {...form.getInputProps("password")}
-            />
+          <form onSubmit={form.onSubmit(handleSubmit)}>
+            <Stack gap="md">
+              <TextInput
+                label="Email"
+                placeholder="your@email.com"
+                type="email"
+                required
+                {...form.getInputProps("email")}
+              />
 
-            <Button type="submit" loading={loading}>
-              Sign In
-            </Button>
+              <PasswordInput
+                label="Password"
+                placeholder="Your password"
+                required
+                {...form.getInputProps("password")}
+              />
 
-            <Text size="sm" c="dimmed" ta="center">
-              <Anchor href="/forgot-password" size="sm">
-                Forgot your password?
-              </Anchor>
-            </Text>
-          </Stack>
-        </form>
-      </Paper>
+              <Text size="sm" c="dimmed" ta="left">
+                <Anchor href="/forgot-password" size="13px">
+                  Forgot your password?
+                </Anchor>
+              </Text>
+
+              <Button type="submit" loading={loading}>
+                Log in
+              </Button>
+
+              <Text ta="center" lh="1">
+                <Text component="span" size="13px" c="#228BE6">
+                  Don't have an account?{" "}
+                </Text>
+
+                <Text component="span" size="13px" c="dimmed" td="underline">
+                  {/*TODO: CHANGE CONTACT EMAIL TO SALVATION ARMY ONE ONCE KNOWN V*/}
+                  <Anchor href="mailto:changeEmail@AtSomePoint.com" size="13px">
+                    Contact an administrator
+                  </Anchor>
+                </Text>
+              </Text>
+            </Stack>
+          </form>
+        </Paper>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Changed the sign in page to better reflect the UI design in the figma. See the images below 

<img width="959" height="497" alt="image" src="https://github.com/user-attachments/assets/ded96990-c7a4-440e-8dea-59d2fd331cb0" />

Desktop view

<img width="201" height="415" alt="image" src="https://github.com/user-attachments/assets/9de241e1-b30a-420d-b50c-2828d6d30b7f" />

Mobile view

Note that the "Contact an administrator" button requires a real email for it to function properly. It currently has a placeholder email address for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned login page with skyline background, centered layout, and logo header
  * Added password input to the login form
  * Added account prompt with "Contact an administrator" mailto link
  * Updated submit button label to "Log in" and restyled forgot-password link

* **Style**
  * New styling for login page elements: title, form card, spacing, responsive height cap, and logo row

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->