### PR TITLE
Sanc 57 large view agencies pages

### DIFF
--- a/src/app/_components/common/navbar.tsx
+++ b/src/app/_components/common/navbar.tsx
@@ -30,6 +30,9 @@ export default function Navbar({ view, agencyName }: NavbarProps) {
 
       {view === "admin" && (
         <Group gap={20}>
+          <Link href="/admin/agencies">
+            <Button text="View Agencies" variant="secondary" />
+          </Link>
           <Link href="/admin/rider-logs">
             <Button text="Rider Logs" variant="secondary" />
           </Link>

--- a/src/app/admin/agencies/agencies.module.scss
+++ b/src/app/admin/agencies/agencies.module.scss
@@ -1,0 +1,44 @@
+.container {
+  padding: 2rem;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.exportButton {
+  min-width: 180px;
+}
+
+.agencyTab {
+  border-radius: 24px;
+  padding: 0.5rem 1.5rem;
+  font-weight: 500;
+
+  &:hover {
+    transform: translateY(-2px);
+    transition: transform 0.2s ease;
+  }
+}
+
+.contentGrid {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 2rem;
+  margin-top: 2rem;
+
+  @media (max-width: 1024px) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.agencyInfoSection {
+  height: fit-content;
+}
+
+.userInfoSection {
+}

--- a/src/app/admin/agencies/agencies.module.scss
+++ b/src/app/admin/agencies/agencies.module.scss
@@ -39,6 +39,3 @@
 .agencyInfoSection {
   height: fit-content;
 }
-
-.userInfoSection {
-}

--- a/src/app/admin/agencies/page.tsx
+++ b/src/app/admin/agencies/page.tsx
@@ -40,8 +40,56 @@ export default function AgenciesPage() {
   }
 
   const handleExportToCSV = () => {
-    // Mock export function - will be implemented later
-    console.log("Exporting to CSV...");
+    if (!selectedAgency) {
+      alert("No agency selected");
+      return;
+    }
+
+    // Create CSV content with agency information first
+    const csvRows = [
+      // Agency Information Section
+      "Agency Information",
+      `Agency Name,"${selectedAgency.name}"`,
+      `Agency Slug,"${selectedAgency.slug}"`,
+      `Date Joined,"${formatDate(selectedAgency.createdAt)}"`,
+      "", // Empty row for separation
+      // Member Information Section
+      "Member Information",
+      "Member Name,Member Email Address,Role,Date Joined",
+    ];
+
+    // Add member data
+    if (selectedAgency.members && selectedAgency.members.length > 0) {
+      selectedAgency.members.forEach((member) => {
+        const row = [
+          `"${member.user.name || "No name"}"`,
+          `"${member.user.email}"`,
+          `"${member.role}"`,
+          `"${formatDate(member.createdAt)}"`,
+        ];
+        csvRows.push(row.join(","));
+      });
+    } else {
+      csvRows.push("No members found");
+    }
+
+    const csvContent = csvRows.join("\n");
+
+    // Create and download the file
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const link = document.createElement("a");
+    const url = URL.createObjectURL(blob);
+
+    link.setAttribute("href", url);
+    link.setAttribute(
+      "download",
+      `${selectedAgency.slug}-members-${new Date().toISOString().split("T")[0]}.csv`,
+    );
+    link.style.visibility = "hidden";
+
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
 
   return (

--- a/src/app/admin/agencies/page.tsx
+++ b/src/app/admin/agencies/page.tsx
@@ -4,6 +4,7 @@ import { Button, Group, Paper, Stack, Table, Text, Title } from "@mantine/core";
 import { useState } from "react";
 import Edit from "@/assets/icons/edit";
 import Grid from "@/assets/icons/grid";
+import Mail from "@/assets/icons/mail";
 import styles from "./agencies.module.scss";
 
 // Mock data
@@ -132,7 +133,7 @@ export default function AgenciesPage() {
                   </Table.Th>
                   <Table.Th>
                     <Group gap="xs">
-                      <span>✉️</span>
+                      <Mail />
                       <Text fw={700}>Member Email Address</Text>
                     </Group>
                   </Table.Th>

--- a/src/app/admin/agencies/page.tsx
+++ b/src/app/admin/agencies/page.tsx
@@ -30,8 +30,7 @@ export default function AgenciesPage() {
       month: "long",
       day: "numeric",
       year: "numeric",
-      timeZone: "UTC",
-    }).format(new Date(date));
+    }).format(date);
   };
 
   if (isLoading) {

--- a/src/app/admin/agencies/page.tsx
+++ b/src/app/admin/agencies/page.tsx
@@ -1,7 +1,155 @@
+"use client";
+
+import { Button, Group, Paper, Stack, Table, Text, Title } from "@mantine/core";
+import { useState } from "react";
+import Edit from "@/assets/icons/edit";
+import Grid from "@/assets/icons/grid";
+import styles from "./agencies.module.scss";
+
+// Mock data
+const mockAgencies = [
+  {
+    id: "1",
+    name: "Amazing Agency",
+    slug: "amazing-agency",
+    dateJoined: "February 25th, 2025",
+  },
+  {
+    id: "2",
+    name: "Fireworks Org",
+    slug: "fireworks-org",
+    dateJoined: "March 10th, 2025",
+  },
+  {
+    id: "3",
+    name: "Star Agency",
+    slug: "star-agency",
+    dateJoined: "January 15th, 2025",
+  },
+  {
+    id: "4",
+    name: "Happy Agency",
+    slug: "happy-agency",
+    dateJoined: "April 5th, 2025",
+  },
+];
+
+const mockMembers = [
+  { id: "1", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "2", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "3", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "4", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "5", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "6", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "7", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "8", name: "Patrick Star", email: "patrick@gmail.com" },
+  { id: "9", name: "Patrick Star", email: "patrick@gmail.com" },
+];
+
 export default function AgenciesPage() {
+  const [selectedAgencyId, setSelectedAgencyId] = useState(mockAgencies[0]?.id ?? "1");
+
+  const selectedAgency = mockAgencies.find((agency) => agency.id === selectedAgencyId);
+
+  const handleExportToCSV = () => {
+    // Mock export function - will be implemented later
+    console.log("Exporting to CSV...");
+  };
+
   return (
-    <div>
-      <h1>View all Agencies</h1>
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Title order={2}>View all Agencies</Title>
+        <Button
+          variant="outline"
+          color="dark"
+          leftSection={<Grid />}
+          onClick={handleExportToCSV}
+          className={styles.exportButton}
+        >
+          Export to CSV File
+        </Button>
+      </div>
+
+      {/* Agency Tabs */}
+      <Group gap="sm" mb="xl">
+        {mockAgencies.map((agency) => (
+          <Button
+            key={agency.id}
+            variant={selectedAgencyId === agency.id ? "filled" : "default"}
+            color={selectedAgencyId === agency.id ? "dark" : "gray"}
+            onClick={() => setSelectedAgencyId(agency.id)}
+            className={styles.agencyTab}
+          >
+            {agency.name}
+          </Button>
+        ))}
+      </Group>
+
+      {/* Agency Information and User Information */}
+      {selectedAgency && (
+        <div className={styles.contentGrid}>
+          {/* Agency Information */}
+          <Paper className={styles.agencyInfoSection}>
+            <Title order={3} mb="lg">
+              Agency Information
+            </Title>
+            <Stack gap="md">
+              <div>
+                <Text fw={700} size="sm" c="dimmed" mb={4}>
+                  Agency Name
+                </Text>
+                <Text size="md">{selectedAgency.name}</Text>
+              </div>
+              <div>
+                <Text fw={700} size="sm" c="dimmed" mb={4}>
+                  Agency Slug
+                </Text>
+                <Text size="md">{selectedAgency.slug}</Text>
+              </div>
+              <div>
+                <Text fw={700} size="sm" c="dimmed" mb={4}>
+                  Date Joined
+                </Text>
+                <Text size="md">{selectedAgency.dateJoined}</Text>
+              </div>
+            </Stack>
+          </Paper>
+
+          {/* User Information */}
+          <Paper className={styles.userInfoSection}>
+            <Title order={3} mb="lg">
+              User Information
+            </Title>
+            <Table striped highlightOnHover>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>
+                    <Group gap="xs">
+                      <Edit />
+                      <Text fw={700}>Member Name</Text>
+                    </Group>
+                  </Table.Th>
+                  <Table.Th>
+                    <Group gap="xs">
+                      <span>✉️</span>
+                      <Text fw={700}>Member Email Address</Text>
+                    </Group>
+                  </Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {mockMembers.map((member) => (
+                  <Table.Tr key={member.id}>
+                    <Table.Td>{member.name}</Table.Td>
+                    <Table.Td>{member.email}</Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Paper>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/admin/agencies/page.tsx
+++ b/src/app/admin/agencies/page.tsx
@@ -1,0 +1,7 @@
+export default function AgenciesPage() {
+  return (
+    <div>
+      <h1>View all Agencies</h1>
+    </div>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -10,10 +10,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   return (
     <HydrateClient>
       <Navbar view="admin" />
-      <main className={styles.adminPage}>
-        <h1 className={styles.title}>Hello, {session.user?.name}</h1>
-        {children}
-      </main>
+      <main className={styles.adminPage}>{children}</main>
     </HydrateClient>
   );
 }

--- a/src/assets/icons/mail.tsx
+++ b/src/assets/icons/mail.tsx
@@ -1,0 +1,32 @@
+import type { SVGProps } from "react";
+import { memo } from "react";
+
+const SvgComponent = ({ width = "20px", height = "20px", ...props }: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="none"
+    viewBox="0 0 24 24"
+    aria-label="Mail"
+    {...props}
+  >
+    <title>Mail</title>
+    <path
+      d="M4 4H20C21.1 4 22 4.9 22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6C2 4.9 2.9 4 4 4Z"
+      stroke="#424242"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M22 6L12 13L2 6"
+      stroke="#424242"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+const Mail = memo(SvgComponent);
+export default Mail;

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -97,7 +97,7 @@ export const organizationRouter = createTRPCRouter({
     }
   }),
 
-  getAllWithMembers: protectedProcedure.query(async ({ ctx }) => {
+  getAllWithMembers: adminProcedure.query(async ({ ctx }) => {
     try {
       const organizations = await ctx.db.query.organization.findMany({
         with: {

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -96,6 +96,27 @@ export const organizationRouter = createTRPCRouter({
       });
     }
   }),
+
+  getAllWithMembers: protectedProcedure.query(async ({ ctx }) => {
+    try {
+      const organizations = await ctx.db.query.organization.findMany({
+        with: {
+          members: {
+            with: {
+              user: true,
+            },
+          },
+        },
+      });
+
+      return organizations;
+    } catch (error) {
+      throw new TRPCError({
+        cause: error,
+        code: "INTERNAL_SERVER_ERROR",
+      });
+    }
+  }),
   inviteUser: adminProcedure
     .input(
       z.object({

--- a/src/server/db/auth-schema.ts
+++ b/src/server/db/auth-schema.ts
@@ -1,4 +1,4 @@
-import { type InferSelectModel, relations } from "drizzle-orm";
+import { relations } from "drizzle-orm";
 import { boolean, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 import { bookings } from "./booking-schema";
 import { logs } from "./vehicle-log";
@@ -114,7 +114,7 @@ export const organizationRelations = relations(organization, ({ many }) => ({
   members: many(member),
 }));
 
-export const memberRelations = relations(member, ({ one }) => ({
+export const memberRelations = relations(member, ({ one, many }) => ({
   organization: one(organization, {
     fields: [member.organizationId],
     references: [organization.id],

--- a/src/server/db/auth-schema.ts
+++ b/src/server/db/auth-schema.ts
@@ -107,6 +107,22 @@ export const invitation = pgTable("invitation", {
 export const userRelations = relations(user, ({ many }) => ({
   driverBookings: many(bookings, { relationName: "driverBookings" }),
   agencyBookings: many(bookings, { relationName: "agencyBookings" }),
+  memberships: many(member),
+}));
+
+export const organizationRelations = relations(organization, ({ many }) => ({
+  members: many(member),
+}));
+
+export const memberRelations = relations(member, ({ one }) => ({
+  organization: one(organization, {
+    fields: [member.organizationId],
+    references: [organization.id],
+  }),
+  user: one(user, {
+    fields: [member.userId],
+    references: [user.id],
+  }),
   driverLogs: many(logs, { relationName: "driverLogs" }),
 }));
 


### PR DESCRIPTION
  ## View Agencies Page

  Adds admin page to view all organizations and their members.

  ### Features
  - **Agency tabs**: Switch between organizations
  - **Agency info**: Display name, slug, and creation date
  - **Member table**: Show all members with names and emails
  - **CSV export**: Download agency and member data

  ### Changes
  **Frontend:**
  - New route: `/admin/agencies`
  - Added "View Agencies" to admin navbar
  - Created mail icon component

  **Backend:**
  - Added `getAllWithMembers` query to fetch organizations with members
  - Added database relations for organizations/members

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "View Agencies" admin navigation action.
  * New Agencies admin interface: tabbed agency selection, agency details, member list, responsive layout, and empty-state messaging.
  * CSV export for agency data.
  * Added a mail icon for messaging UI.

* **Style / UI**
  * Removed greeting header from the admin layout to streamline admin pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->