### PR TITLE
SANC-53: create multipurpose loading screen

### DIFF
--- a/src/app/_components/common/loadingscreen.module.scss
+++ b/src/app/_components/common/loadingscreen.module.scss
@@ -1,0 +1,7 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  width: 100%;
+}

--- a/src/app/_components/common/loadingscreen.tsx
+++ b/src/app/_components/common/loadingscreen.tsx
@@ -1,0 +1,17 @@
+import { Loader, Stack, Text } from "@mantine/core";
+import styles from "./loadingscreen.module.scss";
+
+interface LoadingScreenProps {
+  message?: string;
+}
+
+export default function LoadingScreen({ message = "Loading..." }: LoadingScreenProps) {
+  return (
+    <div className={styles.container}>
+      <Stack align="center" gap="md">
+        <Loader size="lg" color="#A03145" />
+        <Text size="lg">{message}</Text>
+      </Stack>
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,6 +12,7 @@ import { authClient } from "@/lib/auth-client";
 import { notify } from "@/lib/notifications";
 import { api } from "@/trpc/react";
 import { emailRegex } from "@/types/validation";
+import LoadingScreen from "../_components/common/loadingscreen";
 import ui from "./Login.module.scss";
 
 export default function LoginPage() {
@@ -69,6 +70,10 @@ export default function LoginPage() {
       setLoading(false);
     }
   };
+
+  if (sessionLoading || (!sessionLoading && session)) {
+    return <LoadingScreen message="Redirecting..." />;
+  }
 
   return (
     <div className={ui.background}>


### PR DESCRIPTION
made a general loading screen that can take a message and updated the login page to show the loading screen while it is redirecting

question: The colour is hardcoded and I wasn't exactly sure how I'm supposed to use the colour vars in _variables.scss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a loading screen component displayed during login session transitions with customizable messaging and a centered loading indicator.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->