### PR TITLE
SANC-71: Adjust view-controller component for mobile

### DIFF
--- a/src/app/_components/agencycomponents/view-controller.module.scss
+++ b/src/app/_components/agencycomponents/view-controller.module.scss
@@ -1,7 +1,9 @@
 .controlsBar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
   margin-bottom: 1.5rem;
 
   .viewToggles {

--- a/src/app/_components/agencycomponents/view-controller.module.scss
+++ b/src/app/_components/agencycomponents/view-controller.module.scss
@@ -3,23 +3,43 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.5rem;
   margin-bottom: 1.5rem;
 
-  .viewToggles {
+  .leftControls {
     display: flex;
+    align-items: center;
     gap: 0.5rem;
   }
 
-  .navigationControls {
+  .rightControls {
     display: flex;
     align-items: center;
     gap: 1rem;
+  }
 
-    .weekNavigation {
+  .weekNavigation {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  // Mobile: show icon-only button, hide full button
+  .addButtonMobile {
+    display: none;
+  }
+
+  .addButtonDesktop {
+    display: flex;
+  }
+
+  @media (max-width: 768px) {
+    .addButtonMobile {
       display: flex;
-      align-items: center;
-      gap: 0.5rem;
+    }
+
+    .addButtonDesktop {
+      display: none;
     }
   }
 

--- a/src/app/_components/agencycomponents/view-controller.tsx
+++ b/src/app/_components/agencycomponents/view-controller.tsx
@@ -1,6 +1,11 @@
 "use client";
 
+import dayjs, { type Dayjs } from "dayjs";
+import isoWeek from "dayjs/plugin/isoWeek";
+import isToday from "dayjs/plugin/isToday";
+import type React from "react";
 import Button from "@/app/_components/common/button/Button";
+import IconButton from "@/app/_components/common/button/IconButton";
 import SegmentedControl from "@/app/_components/common/segmentedControl";
 import Calendar from "@/assets/icons/calendar";
 import Chevron from "@/assets/icons/chevron";
@@ -8,6 +13,9 @@ import Grid from "@/assets/icons/grid";
 import Plus from "@/assets/icons/plus";
 import type { ViewMode } from "@/types/types";
 import styles from "./view-controller.module.scss";
+
+dayjs.extend(isoWeek);
+dayjs.extend(isToday);
 
 const leftViewOption = {
   value: "calendar",
@@ -21,9 +29,6 @@ const rightViewOption = {
   icon: Grid,
 };
 
-import type React from "react";
-import IconButton from "@/app/_components/common/button/IconButton";
-
 interface ViewControllerProps {
   viewMode: ViewMode;
   setViewMode: React.Dispatch<React.SetStateAction<ViewMode>>;
@@ -33,6 +38,22 @@ interface ViewControllerProps {
   isDayView?: boolean;
 }
 
+// Adjust weekend to nearest weekday (Sun -> Mon, Sat -> Fri)
+const toWeekday = (d: Dayjs): Dayjs => {
+  if (d.day() === 0) return d.add(1, "day");
+  if (d.day() === 6) return d.subtract(1, "day");
+  return d;
+};
+
+// Move to next/previous weekday, skipping weekends
+const moveWeekday = (d: Dayjs, direction: 1 | -1): Dayjs => {
+  let result = d.add(direction, "day");
+  while (result.day() === 0 || result.day() === 6) {
+    result = result.add(direction, "day");
+  }
+  return result;
+};
+
 export const ViewController = ({
   viewMode,
   setViewMode,
@@ -41,92 +62,36 @@ export const ViewController = ({
   onDateChange,
   isDayView = false,
 }: ViewControllerProps) => {
-  // Check if a date is a weekend
-  const isWeekend = (date: Date): boolean => {
-    const day = date.getDay();
-    return day === 0 || day === 6; // Sunday or Saturday
-  };
-
-  // Adjust a weekend day to the nearest weekday
-  const toWeekday = (date: Date): Date => {
-    const d = new Date(date);
-    if (d.getDay() === 0) d.setDate(d.getDate() + 1); // Sunday -> Monday
-    if (d.getDay() === 6) d.setDate(d.getDate() - 1); // Saturday -> Friday
-    return d;
-  };
-
-  // Move to next/previous weekday
-  const moveWeekday = (date: Date, direction: 1 | -1): Date => {
-    const d = new Date(date);
-    do {
-      d.setDate(d.getDate() + direction);
-    } while (isWeekend(d));
-    return d;
-  };
-
-  // Get Monday of the week containing the date
-  const getWeekStart = (date: Date): Date => {
-    const d = new Date(date);
-    const day = d.getDay();
-    const daysFromMonday = day === 0 ? 6 : day - 1; // Sunday is 6 days from Monday
-    d.setDate(d.getDate() - daysFromMonday);
-    return d;
-  };
-
-  // Format date
-  const formatDate = (date: Date): string => {
-    const month = date.toLocaleDateString("en-US", { month: "short" });
-    return `${month} ${date.getDate()}`;
-  };
-
-  // Check if date is today
-  const isToday = (date: Date): boolean => {
-    const today = new Date();
-    return (
-      date.getDate() === today.getDate() &&
-      date.getMonth() === today.getMonth() &&
-      date.getFullYear() === today.getFullYear()
-    );
-  };
-
-  // Format date display text
-  const formatDateDisplay = (date: Date): string => {
-    const weekdayDate = toWeekday(new Date(date));
+  const formatDateDisplay = (): string => {
+    const d = toWeekday(dayjs(currentDate));
 
     if (isDayView) {
-      if (isToday(weekdayDate)) return "Today";
-      const weekday = weekdayDate.toLocaleDateString("en-US", {
-        weekday: "short",
-      });
-      return `${weekday}, ${formatDate(weekdayDate)}`;
+      if (d.isToday()) return "Today";
+      return d.format("ddd, MMM D");
     }
 
-    // Week view
-    const weekStart = getWeekStart(weekdayDate);
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekEnd.getDate() + 4);
+    // Week view: Monday to Friday
+    const weekStart = d.isoWeekday(1); // Monday
+    const weekEnd = weekStart.add(4, "day"); // Friday
+    const today = dayjs();
 
-    const today = new Date();
-    if (weekStart <= today && today <= weekEnd) {
+    if (today >= weekStart && today <= weekEnd) {
       return "This week";
     }
 
-    return `${formatDate(weekStart)} - ${formatDate(weekEnd)}`;
+    return `${weekStart.format("MMM D")} - ${weekEnd.format("MMM D")}`;
   };
 
-  // Navigation handlers
   const handlePrevious = () => {
-    const newDate = isDayView
-      ? moveWeekday(currentDate, -1)
-      : toWeekday(new Date(currentDate.getTime() - 7 * 24 * 60 * 60 * 1000)); // Move back a week in milliseconds
-    onDateChange(newDate);
+    const current = dayjs(currentDate);
+    const newDate = isDayView ? moveWeekday(current, -1) : toWeekday(current.subtract(1, "week"));
+    onDateChange(newDate.toDate());
   };
 
   const handleNext = () => {
-    const newDate = isDayView
-      ? moveWeekday(currentDate, 1)
-      : toWeekday(new Date(currentDate.getTime() + 7 * 24 * 60 * 60 * 1000)); // Move forward a week in milliseconds
-    onDateChange(newDate);
+    const current = dayjs(currentDate);
+    const newDate = isDayView ? moveWeekday(current, 1) : toWeekday(current.add(1, "week"));
+    onDateChange(newDate.toDate());
   };
 
   return (
@@ -157,7 +122,7 @@ export const ViewController = ({
             ariaLabel={isDayView ? "Previous day" : "Previous week"}
             transparent
           />
-          <span>{formatDateDisplay(currentDate)}</span>
+          <span>{formatDateDisplay()}</span>
           <IconButton
             icon={<Chevron rotation="right" />}
             onClick={handleNext}

--- a/src/app/_components/agencycomponents/view-controller.tsx
+++ b/src/app/_components/agencycomponents/view-controller.tsx
@@ -131,7 +131,7 @@ export const ViewController = ({
 
   return (
     <div className={styles.controlsBar}>
-      <div className={styles.viewToggles}>
+      <div className={styles.leftControls}>
         <SegmentedControl
           leftOption={leftViewOption}
           rightOption={rightViewOption}
@@ -139,9 +139,17 @@ export const ViewController = ({
           onChange={setViewMode}
           color="black"
           size="md"
+          hideLabelsOnMobile
         />
+        <div className={styles.addButtonMobile}>
+          <IconButton
+            icon={<Plus />}
+            onClick={() => setShowBookingModal(true)}
+            ariaLabel="Add booking"
+          />
+        </div>
       </div>
-      <div className={styles.navigationControls}>
+      <div className={styles.rightControls}>
         <div className={styles.weekNavigation}>
           <IconButton
             icon={<Chevron rotation="left" />}
@@ -157,7 +165,9 @@ export const ViewController = ({
             transparent
           />
         </div>
-        <Button onClick={() => setShowBookingModal(true)} text="Add booking" icon={<Plus />} />
+        <div className={styles.addButtonDesktop}>
+          <Button onClick={() => setShowBookingModal(true)} text="Add booking" icon={<Plus />} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/_components/agencycomponents/view-controller.tsx
+++ b/src/app/_components/agencycomponents/view-controller.tsx
@@ -73,9 +73,12 @@ export const ViewController = ({
     // Week view: Monday to Friday
     const weekStart = d.isoWeekday(1); // Monday
     const weekEnd = weekStart.add(4, "day"); // Friday
-    const today = dayjs();
+    const today = dayjs().startOf("day");
 
-    if (today >= weekStart && today <= weekEnd) {
+    if (
+      (today.isAfter(weekStart) || today.isSame(weekStart, "day")) &&
+      (today.isBefore(weekEnd) || today.isSame(weekEnd, "day"))
+    ) {
       return "This week";
     }
 

--- a/src/app/_components/common/segmentedControl.module.scss
+++ b/src/app/_components/common/segmentedControl.module.scss
@@ -35,3 +35,9 @@
 .indicator {
   border-radius: 24px;
 }
+
+.labelHideOnMobile {
+  @media (max-width: 768px) {
+    display: none;
+  }
+}

--- a/src/app/_components/common/segmentedControl.module.scss
+++ b/src/app/_components/common/segmentedControl.module.scss
@@ -1,0 +1,37 @@
+.center {
+  gap: 0.25rem;
+}
+
+.iconWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+}
+
+.iconWrapperActive {
+  color: white;
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.iconActive {
+  color: white;
+  filter: brightness(0) invert(1);
+}
+
+.root {
+  border-radius: 24px;
+}
+
+.control {
+  border-radius: 24px;
+}
+
+.indicator {
+  border-radius: 24px;
+}

--- a/src/app/_components/common/segmentedControl.tsx
+++ b/src/app/_components/common/segmentedControl.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { Center, SegmentedControl as MantineSegmentedControl } from "@mantine/core";
-import type React from "react";
+import type { SVGProps } from "react";
+import styles from "./segmentedControl.module.scss";
 
 export interface SegmentedControlOption<T extends string = string> {
   value: T;
   label: string;
-  icon?: React.ComponentType<{ size?: number; style?: React.CSSProperties }>;
+  icon?: React.ComponentType<SVGProps<SVGSVGElement>>;
   disabled?: boolean;
 }
 
@@ -36,22 +37,20 @@ export function SegmentedControl<T extends string = string>({
   readOnly = false,
   disabled = false,
 }: SegmentedControlProps<T>) {
+  const ICON_SIZE = 22;
+
   const data = [
     {
       value: leftOption.value,
       label: leftOption.icon ? (
-        <Center style={{ gap: 8 }}>
+        <Center className={styles.center}>
           <div
-            style={{
-              color: value === leftOption.value ? "white" : "inherit",
-            }}
+            className={`${styles.iconWrapper} ${value === leftOption.value ? styles.iconWrapperActive : ""}`}
           >
             <leftOption.icon
-              size={16}
-              style={{
-                color: value === leftOption.value ? "white" : "inherit",
-                filter: value === leftOption.value ? "brightness(0) invert(1)" : "none",
-              }}
+              width={ICON_SIZE}
+              height={ICON_SIZE}
+              className={`${styles.icon} ${value === leftOption.value ? styles.iconActive : ""}`}
             />
           </div>
           <span>{leftOption.label}</span>
@@ -64,18 +63,14 @@ export function SegmentedControl<T extends string = string>({
     {
       value: rightOption.value,
       label: rightOption.icon ? (
-        <Center style={{ gap: 8 }}>
+        <Center className={styles.center}>
           <div
-            style={{
-              color: value === rightOption.value ? "white" : "inherit",
-            }}
+            className={`${styles.iconWrapper} ${value === rightOption.value ? styles.iconWrapperActive : ""}`}
           >
             <rightOption.icon
-              size={16}
-              style={{
-                color: value === rightOption.value ? "white" : "inherit",
-                filter: value === rightOption.value ? "brightness(0) invert(1)" : "none",
-              }}
+              width={ICON_SIZE}
+              height={ICON_SIZE}
+              className={`${styles.icon} ${value === rightOption.value ? styles.iconActive : ""}`}
             />
           </div>
           <span>{rightOption.label}</span>
@@ -106,16 +101,10 @@ export function SegmentedControl<T extends string = string>({
       readOnly={readOnly}
       disabled={disabled}
       radius="xl"
-      styles={{
-        root: {
-          borderRadius: "24px",
-        },
-        control: {
-          borderRadius: "24px",
-        },
-        indicator: {
-          borderRadius: "24px",
-        },
+      classNames={{
+        root: styles.root,
+        control: styles.control,
+        indicator: styles.indicator,
       }}
     />
   );

--- a/src/app/_components/common/segmentedControl.tsx
+++ b/src/app/_components/common/segmentedControl.tsx
@@ -6,7 +6,7 @@ import styles from "./segmentedControl.module.scss";
 
 export interface SegmentedControlOption<T extends string = string> {
   value: T;
-  label: string;
+  label?: string;
   icon?: React.ComponentType<SVGProps<SVGSVGElement>>;
   disabled?: boolean;
 }
@@ -23,6 +23,7 @@ export interface SegmentedControlProps<T extends string = string> {
   transitionTimingFunction?: string;
   readOnly?: boolean;
   disabled?: boolean;
+  hideLabelsOnMobile?: boolean;
 }
 export function SegmentedControl<T extends string = string>({
   leftOption,
@@ -36,8 +37,10 @@ export function SegmentedControl<T extends string = string>({
   transitionTimingFunction = "ease",
   readOnly = false,
   disabled = false,
+  hideLabelsOnMobile = false,
 }: SegmentedControlProps<T>) {
   const ICON_SIZE = 22;
+  const labelClass = hideLabelsOnMobile ? styles.labelHideOnMobile : "";
 
   const data = [
     {
@@ -53,10 +56,10 @@ export function SegmentedControl<T extends string = string>({
               className={`${styles.icon} ${value === leftOption.value ? styles.iconActive : ""}`}
             />
           </div>
-          <span>{leftOption.label}</span>
+          <span className={labelClass}>{leftOption.label}</span>
         </Center>
       ) : (
-        leftOption.label
+        <span className={labelClass}>{leftOption.label}</span>
       ),
       disabled: leftOption.disabled,
     },
@@ -73,10 +76,10 @@ export function SegmentedControl<T extends string = string>({
               className={`${styles.icon} ${value === rightOption.value ? styles.iconActive : ""}`}
             />
           </div>
-          <span>{rightOption.label}</span>
+          <span className={labelClass}>{rightOption.label}</span>
         </Center>
       ) : (
-        rightOption.label
+        <span className={labelClass}>{rightOption.label}</span>
       ),
       disabled: rightOption.disabled,
     },

--- a/src/app/agency/home/[slug]/agency-page.module.scss
+++ b/src/app/agency/home/[slug]/agency-page.module.scss
@@ -9,3 +9,9 @@
     margin-bottom: 1rem;
   }
 }
+
+@media (max-width: 768px) {
+  .schedulePage {
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
https://codethechangeyyc.atlassian.net/browse/SANC-71

So far I've adjusted the styling of the segmented control component.

Before:
<img width="380" height="60" alt="Screenshot 2026-01-13 at 6 56 28 PM" src="https://github.com/user-attachments/assets/722f6f4b-a334-4ebf-b350-a485d0d736cd" />


After:
<img width="345" height="59" alt="Screenshot 2026-01-13 at 6 56 45 PM" src="https://github.com/user-attachments/assets/fffdc4bf-b503-44cb-a15d-f614e127d87b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved date display and navigation for day/week views with clearer range labels and weekday-aware navigation.
  * Enhanced segmented control behavior: optional labels and mobile-friendly label hiding.

* **Style**
  * Reorganized controls into left/right groups for clearer hierarchy.
  * Better mobile responsiveness: swapped desktop/mobile "Add booking" actions and adjusted spacing, gaps, and padding for small screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->