### PR TITLE
SANC-87 Modify getAll bookings to allow drivers

### DIFF
--- a/src/app/_components/drivercomponents/driver-dashboard.tsx
+++ b/src/app/_components/drivercomponents/driver-dashboard.tsx
@@ -20,7 +20,7 @@ export const DriverDashboard = () => {
 
   let driverTrips = [{}] as Booking[];
 
-  const tripQuery = api.bookings.getDriverTrip.useQuery(
+  const tripQuery = api.bookings.getAll.useQuery(
     {
       startDate: dateJSON.startDate,
       endDate: dateJSON.endDate,

--- a/src/app/_components/drivercomponents/surveyButtons/surveyButtons.tsx
+++ b/src/app/_components/drivercomponents/surveyButtons/surveyButtons.tsx
@@ -27,14 +27,13 @@ export default function SurveyViewToggle({
     initialData: initialSurveys,
     refetchInterval: 60000,
   });
-  const { data: rawBookings = [] } = api.bookings.getAll.useQuery(
+  const { data: bookings = [] } = api.bookings.getAll.useQuery(
     { surveyCompleted: false },
     {
       initialData: initialBookings,
       refetchInterval: 60000,
     },
   );
-  const bookings = rawBookings.filter((b) => b.driverId === session?.user?.id);
 
   return (
     <>

--- a/src/app/_components/drivercomponents/surveyButtons/surveyButtons.tsx
+++ b/src/app/_components/drivercomponents/surveyButtons/surveyButtons.tsx
@@ -4,6 +4,7 @@ import { Group, Stack } from "@mantine/core";
 import { useState } from "react";
 import Button from "@/app/_components/common/button/Button";
 import SurveyNotification from "@/app/_components/drivercomponents/surveyNotification/surveyNotification";
+import { authClient } from "@/lib/auth-client";
 import { api } from "@/trpc/react";
 import type { Booking, Survey } from "@/types/types";
 
@@ -19,19 +20,21 @@ export default function SurveyViewToggle({
   initialSurveys,
 }: SurveyViewToggleProps) {
   const [activeView, setActiveView] = useState<View>("pending");
+  const { data: session } = authClient.useSession();
 
   // will update every 60 seconds
   const { data: surveys = [] } = api.surveys.getAll.useQuery(undefined, {
     initialData: initialSurveys,
     refetchInterval: 60000,
   });
-  const { data: bookings = [] } = api.bookings.getAll.useQuery(
+  const { data: rawBookings = [] } = api.bookings.getAll.useQuery(
     { surveyCompleted: false },
     {
       initialData: initialBookings,
       refetchInterval: 60000,
     },
   );
+  const bookings = rawBookings.filter((b) => b.driverId === session?.user?.id);
 
   return (
     <>

--- a/src/app/_components/drivercomponents/surveyButtons/surveyButtons.tsx
+++ b/src/app/_components/drivercomponents/surveyButtons/surveyButtons.tsx
@@ -4,7 +4,6 @@ import { Group, Stack } from "@mantine/core";
 import { useState } from "react";
 import Button from "@/app/_components/common/button/Button";
 import SurveyNotification from "@/app/_components/drivercomponents/surveyNotification/surveyNotification";
-import { authClient } from "@/lib/auth-client";
 import { api } from "@/trpc/react";
 import type { Booking, Survey } from "@/types/types";
 
@@ -20,7 +19,6 @@ export default function SurveyViewToggle({
   initialSurveys,
 }: SurveyViewToggleProps) {
   const [activeView, setActiveView] = useState<View>("pending");
-  const { data: session } = authClient.useSession();
 
   // will update every 60 seconds
   const { data: surveys = [] } = api.surveys.getAll.useQuery(undefined, {

--- a/src/server/api/routers/bookings.ts
+++ b/src/server/api/routers/bookings.ts
@@ -148,7 +148,7 @@ export const bookingsRouter = createTRPCRouter({
         conditions.push(eq(bookings.surveyCompleted, input.surveyCompleted));
       }
 
-      if (role === "admin") {
+      if (role === "admin" || role === "driver") {
         return ctx.db
           .select()
           .from(bookings)


### PR DESCRIPTION
Changed getAll api endpoint to get all bookings if role is driver. Changed query in driver-dashboard.tsx to getAll instead of getDriverTrip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Drivers can now reliably view their assigned bookings and trips in the driver dashboard; data is correctly returned for driver accounts.
* **Improvements**
  * Survey buttons now retrieve the authenticated session to enable driver-specific behavior and future personalization of survey requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->