### PR TITLE
SANC-89: Fix Create Agency Bug

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -23,7 +23,6 @@ export default function ForgotPasswordPage() {
 
   const sendResetEmailMutation = api.organization.sendPasswordResetEmail.useMutation({
     onSuccess: (data) => {
-      notify.success(`Password reset link sent to ${data.email}`);
       setIsSuccess(true);
     },
     onError: (error) => {
@@ -48,7 +47,8 @@ export default function ForgotPasswordPage() {
 
           <Stack gap="md">
             <Text size="sm">
-              We've sent a password reset link to <strong>{form.values.email}</strong>.
+              If this email exists in our system, check <strong>{form.values.email}</strong> for the
+              reset link.
             </Text>
 
             <Text size="sm" c="dimmed">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,10 +2,12 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import { organization } from "better-auth/plugins";
+import { and, eq } from "drizzle-orm";
 import RegisterAccountEmailTemplate from "@/app/_components/common/emails/register-account";
 import ResetPasswordEmailTemplate from "@/app/_components/common/emails/reset-password";
 import { resend } from "@/lib/emails";
 import { db } from "@/server/db";
+import { member as memberTable, organization as organizationTable } from "@/server/db/auth-schema";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
@@ -80,11 +82,29 @@ export const auth = betterAuth({
     nextCookies(),
     organization({
       allowUserToCreateOrganization: async (user) => {
-        // Check if user has admin role
-        const member = await db.query.member.findFirst({
-          where: (member, { eq }) => eq(member.userId, user.id),
-        });
-        return member?.role === "admin";
+        //Check if the user is part of the admin org
+        const listOfMembers = await db
+          .select()
+          .from(memberTable)
+          .where(
+            and(
+              eq(memberTable.userId, user.id),
+              eq(
+                memberTable.organizationId,
+                db
+                  .select({ id: organizationTable.id })
+                  .from(organizationTable)
+                  .where(eq(organizationTable.slug, "admins"))
+                  .limit(1),
+              ),
+            ),
+          )
+          .limit(1);
+
+        return (
+          listOfMembers.length !== 0 &&
+          (listOfMembers[0]?.role === "admin" || listOfMembers[0]?.role === "owner")
+        );
       },
     }),
   ],

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 import { auth } from "@/lib/auth";
@@ -9,7 +9,7 @@ import {
   protectedProcedure,
   publicProcedure,
 } from "@/server/api/trpc";
-import { user } from "@/server/db/auth-schema";
+import { member, organization, user } from "@/server/db/auth-schema";
 import { OrganizationRole, Role } from "@/types/types";
 import { nameRegex, passwordSchema } from "@/types/validation";
 
@@ -207,26 +207,54 @@ export const organizationRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      const currentUserMember = await ctx.db.query.member.findFirst({
-        where: (member, { eq }) => eq(member.userId, ctx.session.user.id),
-      });
+      const listOfMembers = await ctx.db
+        .select()
+        .from(member)
+        .where(
+          and(
+            eq(member.userId, ctx.session.user.id),
+            eq(
+              member.organizationId,
+              ctx.db
+                .select({ id: organization.id })
+                .from(organization)
+                .where(eq(organization.slug, "admins"))
+                .limit(1),
+            ),
+          ),
+        )
+        .limit(1);
 
-      if (currentUserMember?.role !== "admin" && currentUserMember?.role !== "owner") {
+      if (listOfMembers.length === 0) {
+        //User is not part of the Admin org
         throw new TRPCError({
           code: "FORBIDDEN",
           message: "Only admins can create organizations",
         });
+      } else if (listOfMembers[0]?.role !== "admin" && listOfMembers[0]?.role !== "owner") {
+        //User has insufficient privileges
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "Insufficient privileges to create organizations",
+        });
       }
 
-      const org = await auth.api.createOrganization({
-        body: {
-          name: input.name,
-          slug: input.slug,
-        },
-        headers: ctx.headers,
-      });
+      try {
+        const org = await auth.api.createOrganization({
+          body: {
+            name: input.name,
+            slug: input.slug,
+          },
+          headers: ctx.headers,
+        });
 
-      return org;
+        return org;
+      } catch {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Internal server error encountered when creating an organization",
+        });
+      }
     }),
 
   // not sure if this can be public... I think it's fine since we are just verifying the token in db


### PR DESCRIPTION
Discovered the following bugs when creating an agency:
1. Owners of the `Admin` organization could not create an agency
2. Users who are admins in any organization could create an agency

This has been fixed, so that only owners and admins of the `Admin` organization can create agencies


[](https://github.com/user-attachments/assets/3467ae78-b5d3-4f20-8775-0cc25222dc19)

In addition, a text change on the `/forgot-password` was done to better inform users who attempt to reset their password

Before:
<img width="242" height="170" alt="image" src="https://github.com/user-attachments/assets/84121c55-e581-47f7-9512-08a741fe9061" />

After:
<img width="293" height="199" alt="image" src="https://github.com/user-attachments/assets/cd7d0187-dec7-45fa-a706-fd44e47a0d6e" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated password reset confirmation message to be less specific about email confirmation.
  * Strengthened authorization checks for administrative operations.

* **Bug Fixes**
  * Improved error handling and messaging for organization creation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->