### PR TITLE
Sanc 90 add driver phone number

### DIFF
--- a/drizzle/seed.ts
+++ b/drizzle/seed.ts
@@ -116,6 +116,7 @@ async function seedUsers() {
     console.log("\nCreating driver user...");
     const driverEmail = "driver@salvationarmy.com";
     const existingDriver = await db.select().from(user).where(eq(user.email, driverEmail)).limit(1);
+    const driverPhoneNumber = "+14031234567";
 
     let driverUser: User;
     if (existingDriver.length > 0) {
@@ -133,6 +134,10 @@ async function seedUsers() {
         },
       });
       await db.update(user).set({ role: "driver" }).where(eq(user.email, driverEmail));
+      await db
+        .update(user)
+        .set({ phoneNumber: driverPhoneNumber })
+        .where(eq(user.email, driverEmail));
       console.log("Driver user created and role updated to driver");
       driverUser = res.user as User;
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "postgres": "^3.4.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-phone-number-input": "^3.4.16",
     "resend": "^6.4.2",
     "sass": "1.93.2",
     "server-only": "^0.0.1",

--- a/src/app/complete-registration/page.tsx
+++ b/src/app/complete-registration/page.tsx
@@ -16,7 +16,7 @@ function CompleteRegistrationContent() {
   const token = searchParams.get("token");
 
   const {
-    data: userEmail,
+    data: userData,
     isLoading,
     isError,
   } = api.organization.verifyTokenAndReturnUserEmail.useQuery(
@@ -44,6 +44,7 @@ function CompleteRegistrationContent() {
     initialValues: {
       password: "",
       confirmPassword: "",
+      phoneNumber: "",
     },
     validate: {
       password: (value) => {
@@ -52,6 +53,12 @@ function CompleteRegistrationContent() {
       },
       confirmPassword: (value, values) =>
         value === values.password ? null : "Passwords do not match",
+      phoneNumber: (value) => {
+        if (userData?.role === "driver") {
+          return value.length > 0 ? null : "Phone number is required";
+        }
+        return null;
+      },
     },
   });
 
@@ -64,6 +71,7 @@ function CompleteRegistrationContent() {
     resetPasswordMutation.mutate({
       token: token,
       newPassword: values.password,
+      phoneNumber: userData?.role === "driver" ? values.phoneNumber : undefined,
     });
   };
 
@@ -86,7 +94,7 @@ function CompleteRegistrationContent() {
     );
   }
 
-  if (isError || !userEmail) {
+  if (isError || !userData) {
     return (
       <div className={styles.center}>
         <Title order={2}>Invalid Invitation Link</Title>
@@ -113,7 +121,7 @@ function CompleteRegistrationContent() {
             <Stack gap="md" className={styles.formStack}>
               <TextInput
                 label="Email"
-                value={userEmail ?? "Loading..."}
+                value={userData.email ?? "Loading..."}
                 disabled
                 description="This is the email address you were invited with"
               />
@@ -132,6 +140,15 @@ function CompleteRegistrationContent() {
                 required
                 {...form.getInputProps("confirmPassword")}
               />
+
+              {userData.role === "driver" && (
+                <TextInput
+                  label="Phone Number"
+                  placeholder="Enter your phone number"
+                  required
+                  {...form.getInputProps("phoneNumber")}
+                />
+              )}
 
               <Button type="submit" fullWidth loading={resetPasswordMutation.isPending} mt="md">
                 Complete Registration

--- a/src/app/complete-registration/page.tsx
+++ b/src/app/complete-registration/page.tsx
@@ -4,6 +4,9 @@ import { Button, Paper, PasswordInput, Stack, Text, TextInput, Title } from "@ma
 import { useForm } from "@mantine/form";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense } from "react";
+import PhoneInput from "react-phone-number-input";
+import "react-phone-number-input/style.css";
+
 import styles from "@/app/_components/common/auth-layout.module.scss";
 import { notify } from "@/lib/notifications";
 import { api } from "@/trpc/react";
@@ -142,12 +145,33 @@ function CompleteRegistrationContent() {
               />
 
               {userData.role === "driver" && (
-                <TextInput
-                  label="Phone Number"
-                  placeholder="Enter your phone number"
-                  required
-                  {...form.getInputProps("phoneNumber")}
-                />
+                <div>
+                  <Text size="sm" fw={500} mb={4}>
+                    Phone Number{" "}
+                    <Text span c="red">
+                      *
+                    </Text>
+                  </Text>
+
+                  <PhoneInput
+                    international
+                    defaultCountry="CA"
+                    countryCallingCodeEditable={false}
+                    placeholder="Enter phone number"
+                    value={form.values.phoneNumber || undefined}
+                    onChange={(value) => form.setFieldValue("phoneNumber", value ?? "")}
+                  />
+
+                  <Text size="xs" c="dimmed" mt={4}>
+                    Used for driver contact and SMS notifications
+                  </Text>
+
+                  {form.errors.phoneNumber && (
+                    <Text size="xs" c="red" mt={4}>
+                      {form.errors.phoneNumber}
+                    </Text>
+                  )}
+                </div>
               )}
 
               <Button type="submit" fullWidth loading={resetPasswordMutation.isPending} mt="md">

--- a/src/app/complete-registration/page.tsx
+++ b/src/app/complete-registration/page.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 import styles from "@/app/_components/common/auth-layout.module.scss";
 import { notify } from "@/lib/notifications";
 import { api } from "@/trpc/react";
-import { passwordSchema } from "@/types/validation";
+import { passwordSchema, phoneNumberSchema } from "@/types/validation";
 
 function CompleteRegistrationContent() {
   const searchParams = useSearchParams();
@@ -54,10 +54,10 @@ function CompleteRegistrationContent() {
       confirmPassword: (value, values) =>
         value === values.password ? null : "Passwords do not match",
       phoneNumber: (value) => {
-        if (userData?.role === "driver") {
-          return value.length > 0 ? null : "Phone number is required";
-        }
-        return null;
+        if (userData?.role !== "driver") return null;
+        if (!value || value.trim().length === 0) return "Phone number is required";
+        const res = phoneNumberSchema.safeParse(value.trim());
+        return res.success ? null : (res.error.message ?? "Invalid phone number format");
       },
     },
   });

--- a/src/app/complete-registration/page.tsx
+++ b/src/app/complete-registration/page.tsx
@@ -60,7 +60,7 @@ function CompleteRegistrationContent() {
         if (userData?.role !== "driver") return null;
         if (!value || value.trim().length === 0) return "Phone number is required";
         const res = phoneNumberSchema.safeParse(value.trim());
-        return res.success ? null : (res.error.message ?? "Invalid phone number format");
+        return res.success ? null : (res.error.issues[0]?.message ?? "Invalid phone number format");
       },
     },
   });

--- a/src/app/debug/bookings/page.tsx
+++ b/src/app/debug/bookings/page.tsx
@@ -15,6 +15,8 @@ import { DateInput, TimeInput } from "@mantine/dates";
 import { useForm } from "@mantine/form";
 import { notifications } from "@mantine/notifications";
 import { useEffect, useMemo, useState } from "react";
+import PhoneInput from "react-phone-number-input";
+import "react-phone-number-input/style.css";
 import { api } from "@/trpc/react";
 import { BOOKING_STATUSES, BookingStatus, type BookingStatusValue } from "@/types/types";
 import styles from "./BookingDebugPage.module.scss";
@@ -47,7 +49,7 @@ const EXAMPLE_BOOKING = {
   pickupAddress: "The Inn from the Cold, 110 11 Ave SE, Calgary, AB",
   destinationAddress: "Sheldon M. Chumir Health Centre, 1213 4 St SW, Calgary, AB",
   passengerInfo: "John Smith",
-  phoneNumber: "+1 (403) 760-9834",
+  phoneNumber: "+14037609834",
   purpose: "Medical appointment",
   start: "2026-02-12T15:00:00.000Z", // Feb 12, 2026 3:00 PM UTC
 };
@@ -361,12 +363,24 @@ export default function BookingDebugPage() {
           {...form.getInputProps("destinationAddress")}
         />
         <TextInput withAsterisk label="Passenger Info" {...form.getInputProps("passengerInfo")} />
-        <TextInput
-          label="Phone number (optional)"
-          placeholder="+1 (403) 760-9834"
-          maxLength={25}
-          {...form.getInputProps("phoneNumber")}
-        />
+        <div>
+          <Text size="sm" fw={500} mb={4}>
+            Phone number (optional)
+          </Text>
+          <PhoneInput
+            international
+            defaultCountry="CA"
+            countryCallingCodeEditable={false}
+            placeholder="Enter phone number"
+            value={form.values.phoneNumber || undefined}
+            onChange={(value) => form.setFieldValue("phoneNumber", value ?? "")}
+          />
+          {form.errors.phoneNumber && (
+            <Text size="xs" c="red" mt={4}>
+              {form.errors.phoneNumber}
+            </Text>
+          )}
+        </div>
         <TextInput withAsterisk label="Agency ID" {...form.getInputProps("agencyId")} />
         <TextInput label="Purpose (optional)" {...form.getInputProps("purpose")} />
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,6 +20,11 @@ export const auth = betterAuth({
   },
   user: {
     additionalFields: {
+      phoneNumber: {
+        type: "string",
+        required: false,
+        input: false,
+      },
       role: {
         type: "string",
         required: true,

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -284,13 +284,7 @@ export const organizationRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      await auth.api.resetPassword({
-        body: {
-          token: input.token,
-          newPassword: input.newPassword,
-        },
-      });
-
+      let userId: string | null = null;
       if (input.phoneNumber != null) {
         const identifier = `reset-password:${input.token}`;
         const verification = await ctx.db.query.verification.findFirst({
@@ -300,13 +294,22 @@ export const organizationRouter = createTRPCRouter({
           const account = await ctx.db.query.account.findFirst({
             where: (account, { eq }) => eq(account.accountId, verification.value),
           });
-          if (account) {
-            await ctx.db
-              .update(user)
-              .set({ phoneNumber: input.phoneNumber })
-              .where(eq(user.id, account.userId));
-          }
+          if (account) userId = account.userId;
         }
+      }
+
+      await auth.api.resetPassword({
+        body: {
+          token: input.token,
+          newPassword: input.newPassword,
+        },
+      });
+
+      if (input.phoneNumber != null && userId != null) {
+        await ctx.db
+          .update(user)
+          .set({ phoneNumber: input.phoneNumber })
+          .where(eq(user.id, userId));
       }
     }),
 

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -273,7 +273,7 @@ export const organizationRouter = createTRPCRouter({
         });
       }
 
-      return user.email;
+      return { email: user.email, role: user.role };
     }),
   resetPassword: publicProcedure
     .input(

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -11,7 +11,7 @@ import {
 } from "@/server/api/trpc";
 import { user } from "@/server/db/auth-schema";
 import { OrganizationRole, Role } from "@/types/types";
-import { nameRegex, passwordSchema } from "@/types/validation";
+import { nameRegex, passwordSchema, phoneNumberSchema } from "@/types/validation";
 
 export const organizationRouter = createTRPCRouter({
   redirectToDashboard: protectedProcedure.mutation(async ({ ctx }) => {
@@ -280,7 +280,7 @@ export const organizationRouter = createTRPCRouter({
       z.object({
         token: z.string(),
         newPassword: passwordSchema,
-        phoneNumber: z.string().max(25).optional(),
+        phoneNumber: phoneNumberSchema,
       }),
     )
     .mutation(async ({ input, ctx }) => {

--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -280,15 +280,34 @@ export const organizationRouter = createTRPCRouter({
       z.object({
         token: z.string(),
         newPassword: passwordSchema,
+        phoneNumber: z.string().max(25).optional(),
       }),
     )
-    .mutation(async ({ input }) => {
+    .mutation(async ({ input, ctx }) => {
       await auth.api.resetPassword({
         body: {
           token: input.token,
           newPassword: input.newPassword,
         },
       });
+
+      if (input.phoneNumber != null) {
+        const identifier = `reset-password:${input.token}`;
+        const verification = await ctx.db.query.verification.findFirst({
+          where: (verification, { eq }) => eq(verification.identifier, identifier),
+        });
+        if (verification) {
+          const account = await ctx.db.query.account.findFirst({
+            where: (account, { eq }) => eq(account.accountId, verification.value),
+          });
+          if (account) {
+            await ctx.db
+              .update(user)
+              .set({ phoneNumber: input.phoneNumber })
+              .where(eq(user.id, account.userId));
+          }
+        }
+      }
     }),
 
   sendPasswordResetEmail: publicProcedure

--- a/src/server/db/auth-schema.ts
+++ b/src/server/db/auth-schema.ts
@@ -8,6 +8,7 @@ export const user = pgTable("user", {
   name: text("name").notNull(),
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").default(false).notNull(),
+  phoneNumber: text("phone_number").unique(),
   image: text("image"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -7,6 +7,12 @@ export const passwordSchema = z
   .regex(/[a-z]/, "Password must contain at least one lowercase letter")
   .regex(/[0-9]/, "Password must contain at least one number");
 
+export const phoneNumberSchema = z
+  .string()
+  .trim()
+  .regex(/^\+[1-9]\d{1,14}$/, "Phone number must be in international format, like +14031231234")
+  .optional();
+
 export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export const nameRegex =

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,11 @@ chokidar@^4.0.0:
   dependencies:
     readdirp "^4.0.1"
 
+classnames@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
@@ -1479,6 +1484,11 @@ copy-anything@^4:
   integrity sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==
   dependencies:
     is-what "^5.2.0"
+
+country-flag-icons@^1.6.14:
+  version "1.6.15"
+  resolved "https://registry.yarnpkg.com/country-flag-icons/-/country-flag-icons-1.6.15.tgz#f89014f84534d4f35109280d88930e6c371684a9"
+  integrity sha512-92HoA8l6DluEidku8tKBftjuFRj4Rv3zDW1lXxCuNnqAxhUSkvso9gM/Afj4F5BnK+wneHIe3ydI+s+4NA29/Q==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1853,6 +1863,13 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
+input-format@^0.3.14:
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/input-format/-/input-format-0.3.14.tgz#7aea985e2a5b258d2cdd853ac7cc10bac1b2a8b8"
+  integrity sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==
+  dependencies:
+    prop-types "^15.8.1"
+
 invariant@2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
@@ -2009,6 +2026,11 @@ less@^4.2.0:
     mime "^1.4.1"
     needle "^3.1.0"
     source-map "~0.6.0"
+
+libphonenumber-js@^1.12.37:
+  version "1.12.39"
+  resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.12.39.tgz#267ca7a23a187b1366ade8a7b45d38f766469347"
+  integrity sha512-MW79m7HuOqBk8mwytiXYTMELJiBbV3Zl9Y39dCCn1yC8K+WGNSq1QGvzywbylp5vGShEztMScCWHX/XFOS0rXg==
 
 lilconfig@^2.0.5:
   version "2.1.0"
@@ -2429,6 +2451,17 @@ react-number-format@^5.4.4:
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/react-number-format/-/react-number-format-5.4.4.tgz#d31f0e260609431500c8d3f81bbd3ae1fb7cacad"
   integrity sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==
+
+react-phone-number-input@^3.4.16:
+  version "3.4.16"
+  resolved "https://registry.yarnpkg.com/react-phone-number-input/-/react-phone-number-input-3.4.16.tgz#e442cdb790ce3138c14e1a705b4e254528855aff"
+  integrity sha512-ix1+SIyGuLxnlAeW+XQNhwOmmDd4Zmr6Ng1eQl0E2XS8xIuue3gdZeBG4LGTMjTIFneOTO9pUPL+AEDhV6+r+A==
+  dependencies:
+    classnames "^2.5.1"
+    country-flag-icons "^1.6.14"
+    input-format "^0.3.14"
+    libphonenumber-js "^1.12.37"
+    prop-types "^15.8.1"
 
 react-remove-scroll-bar@^2.3.7:
   version "2.3.8"


### PR DESCRIPTION
- Added optional phone number field to the user table (nullable; used for drivers).
- Seeded driver user with a phone number in the seed script.
- Exposed phone number on the auth session so it’s available in the app.
- Complete-registration page shows a phone field only when the invited user is a driver.
- Driver phone is required on complete-registration and saved when they set their password.
- Validated and stored driver phone in E.164 for future SMS.
- Replaced phone input fields with a country-code + formatted phone input on complete-registration and the booking debug page: 
<img width="704" height="93" alt="image" src="https://github.com/user-attachments/assets/e6f0b2e8-5a86-4167-9f45-0a6a50ce9f40" />

The image is from the booking debug page version. 
I cannot figure out how to actually view the complete registration one right now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Driver registration now requires/accepts a validated phone number input.
  * Booking creation form includes an improved phone number input with formatting and validation.
  * Password reset flow can accept a phone number and will persist it to the user account when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->