### PR TITLE
SANC-93: Driver Calendar Cannot be Displayed

### DIFF
--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -18,9 +18,9 @@ export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const nameRegex =
   /^(?!.*\s{2})[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9]$/;
 
-export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}$/; //ISO timestamp regex in MST for 5+ digit years
+export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}$/; //ISO timestamp regex for 5+ digit years
 
-export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}$/; //ISO timestamp regex in MST for 4 digit years
+export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}$/; //ISO timestamp regex for 4 digit years
 
 /**
  * Validates a string's length with both minimum and maximum constraints.

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -18,9 +18,9 @@ export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const nameRegex =
   /^(?!.*\s{2})[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9]$/;
 
-export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}$/; //ISO timestamp regex in MST for 5+ digit years
+export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}$/; //ISO timestamp regex in MST for 5+ digit years
 
-export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}$/; //ISO timestamp regex in MST for 4 digit years
+export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[-+]\d{2}:\d{2}$/; //ISO timestamp regex in MST for 4 digit years
 
 /**
  * Validates a string's length with both minimum and maximum constraints.

--- a/src/types/validation.ts
+++ b/src/types/validation.ts
@@ -18,9 +18,9 @@ export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const nameRegex =
   /^(?!.*\s{2})[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9][A-Za-z0-9\s]*[A-Za-z0-9]$/;
 
-export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-07:00$/; //ISO timestamp regex in MST for 5+ digit years
+export const isoTimeRegex = /^\+\d{5,}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}$/; //ISO timestamp regex in MST for 5+ digit years
 
-export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-07:00$/; //ISO timestamp regex in MST for 4 digit years
+export const isoTimeRegexFourDigitYears = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}$/; //ISO timestamp regex in MST for 4 digit years
 
 /**
  * Validates a string's length with both minimum and maximum constraints.


### PR DESCRIPTION
Found an error when attempting to load a driver's trips. The calendar will not display and the user is stuck in at the loading screen indefinitely

The error was that the `bookings.getDriverTrip` endpoint uses incorrectly formatted regexes to check its inputs. The regexes are too strict in that it only allows for dates in UTC-7. This has been changed to allow other time zones

The video below shows the bug, as well as the changes made in the PR to address it

[](https://github.com/user-attachments/assets/6dc17c13-881e-4945-b418-1fdd4c5153c3)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ISO 8601 timestamp validation now accepts any ±HH:MM timezone offset (instead of a single fixed offset) for both standard and four-digit-year timestamp formats, improving compatibility with varied timezone representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->