### PR TITLE
SANC-102: save user role to db

### DIFF
--- a/src/server/api/routers/organizations.ts
+++ b/src/server/api/routers/organizations.ts
@@ -131,6 +131,7 @@ export const organizationRouter = createTRPCRouter({
         email: z.string().email(),
         organizationRole: z.nativeEnum(OrganizationRole),
         organizationId: z.string(),
+        role: z.nativeEnum(Role),
       }),
     )
     .mutation(async ({ input, ctx }) => {
@@ -173,6 +174,8 @@ export const organizationRouter = createTRPCRouter({
             role: input.organizationRole,
           },
         });
+
+        await ctx.db.update(user).set({ role: input.role }).where(eq(user.id, newUser.user.id));
 
         // send the invitation email using the forgot password flow
         console.log("Sending password reset email to:", input.email);


### PR DESCRIPTION
When inviting a new user, the user was being created in the user table but their role was never set, so they always defaulted to "driver". 
Added a db update after the user is created to explicitly set their role to whatever is selected (admin, driver, or agency).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User invitations to organizations now require specifying a role during the invitation process. When users are invited to join an organization, they will be assigned their designated role upon completing the invitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->