### PR TITLE
Error msg for passenger fit rating

### DIFF
--- a/src/app/_components/drivercomponents/TripSurveyModal.tsx
+++ b/src/app/_components/drivercomponents/TripSurveyModal.tsx
@@ -185,7 +185,16 @@ export const TripSurveyModal = ({ form }: SurveyFormProps) => {
           disabled={form.values.tripCompletionStatus === BookingStatus.CANCELLED}
         ></SegmentedControl>
         Rate the passenger’s fitness for transport
-        <div className={styles.rating}>
+        <div
+          className={styles.rating}
+          style={{
+            border: form.errors.passengerFitRating
+              ? "1px solid var(--mantine-color-red-6)"
+              : "none",
+            borderRadius: 4,
+            padding: form.errors.passengerFitRating ? 4 : 0,
+          }}
+        >
           <Rating
             styles={{
               root: {
@@ -204,6 +213,11 @@ export const TripSurveyModal = ({ form }: SurveyFormProps) => {
         </div>
         <Group justify="space-between" className={styles.ratingLabel}>
           <Text>Very Poor</Text>
+          {form.errors.passengerFitRating && (
+            <Text size="xs" c="red">
+              {form.errors.passengerFitRating}
+            </Text>
+          )}
           <Text>Excellent</Text>
         </Group>
         Additional Notes


### PR DESCRIPTION
<img width="1454" height="361" alt="image" src="https://github.com/user-attachments/assets/bc34cbee-d624-46fe-925b-d84952f44cb4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error display for the passenger fitness rating. When validation errors occur, the rating field now displays a red border with adjusted styling, and error messages appear below the rating labels for clearer user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->